### PR TITLE
Center isPending icon of Button

### DIFF
--- a/src/components/Button/ButtonPending.tsx
+++ b/src/components/Button/ButtonPending.tsx
@@ -29,11 +29,7 @@ export const ButtonPending = forwardRef<HTMLSpanElement, ButtonPendingProps>(
       {...props}
     >
       {isPending && (
-        <div
-          className="absolute -top-0.5 left-1/2 -translate-x-1/2"
-          aria-hidden
-          data-testid="ButtonPending"
-        >
+        <div className="absolute" aria-hidden data-testid="ButtonPending">
           <Loader2 className="animate-spin" />
         </div>
       )}


### PR DESCRIPTION
# Center isPending icon of Button

## :recycle: Current situation & Problem
Pending button icon is not vertically centered.


## :gear: Release Notes 
* Center icon of pending Button


## :white_check_mark: Testing
Fixed `isPending` state:
![image](https://github.com/user-attachments/assets/d004e532-6914-4052-8acc-b8cadef31abf)



## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
