### PR TITLE
Add Field tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -37,7 +37,7 @@ export const TooltipContent = forwardRef<
 ))
 TooltipContent.displayName = RadixTooltip.Content.displayName
 
-interface TooltipProps
+export interface TooltipProps
   extends Omit<ComponentPropsWithoutRef<typeof RadixTooltip.Root>, 'children'>,
     Pick<
       ComponentPropsWithoutRef<typeof RadixTooltip.Content>,

--- a/src/forms/Field/Field.stories.tsx
+++ b/src/forms/Field/Field.stories.tsx
@@ -65,3 +65,16 @@ export const Error = () => {
     />
   )
 }
+
+export const Tooltip = () => {
+  const form = useForm({ formSchema })
+  return (
+    <Field
+      control={form.control}
+      name="name"
+      label="Name"
+      tooltip="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+      render={({ field }) => <Input {...field} />}
+    />
+  )
+}

--- a/src/forms/Field/Field.test.tsx
+++ b/src/forms/Field/Field.test.tsx
@@ -76,8 +76,8 @@ describe('Field', () => {
       'More information about the name field',
     )
 
+    expect(tooltipTrigger).not.toHaveAccessibleDescription('Tooltip content')
     await user.hover(tooltipTrigger)
-
     expect(tooltipTrigger).toHaveAccessibleDescription('Tooltip content')
   })
 })

--- a/src/forms/Field/Field.test.tsx
+++ b/src/forms/Field/Field.test.tsx
@@ -67,4 +67,17 @@ describe('Field', () => {
     const input = screen.getByRole('textbox')
     expect(input).toHaveAccessibleErrorMessage('Custom error')
   })
+
+  it('renders accessible tooltip', async () => {
+    const user = userEvent.setup()
+    render(<Component tooltip="Tooltip content" />)
+
+    const tooltipTrigger = screen.getByLabelText(
+      'More information about the name field',
+    )
+
+    await user.hover(tooltipTrigger)
+
+    expect(tooltipTrigger).toHaveAccessibleDescription('Tooltip content')
+  })
 })

--- a/src/forms/Field/Field.tsx
+++ b/src/forms/Field/Field.tsx
@@ -80,14 +80,14 @@ export const Field = <
         }
         return (
           <div className={className}>
-            {(tooltip ?? label) && (
+            {tooltip || label ?
               <div className="mb-2 flex gap-2">
                 {label && <Label htmlFor={id}>{label}</Label>}
                 {tooltip && (
                   <FieldTooltip tooltip={tooltip} label={label} id={id} />
                 )}
               </div>
-            )}
+            : null}
             {render({
               ...states,
               field: fieldProps,

--- a/src/forms/Field/Field.tsx
+++ b/src/forms/Field/Field.tsx
@@ -17,6 +17,7 @@ import {
   type FieldValues,
   type UseFormStateReturn,
 } from 'react-hook-form'
+import { FieldTooltip } from './FieldTooltip'
 import { Error } from '../../components/Error'
 import { Label } from '../../components/Label'
 
@@ -41,6 +42,10 @@ export type FieldProps<
   className?: string
   checkEmptyError?: boolean
   error?: ErrorOption
+  /**
+   * Adds tooltip on top of field, helpful for explaining details about field
+   * */
+  tooltip?: ReactNode
 }
 
 /**
@@ -56,6 +61,7 @@ export const Field = <
   checkEmptyError,
   render,
   error: errorProp,
+  tooltip,
   ...props
 }: FieldProps<TFieldValues, TName>) => {
   const id = name
@@ -74,10 +80,13 @@ export const Field = <
         }
         return (
           <div className={className}>
-            {label && (
-              <Label htmlFor={id} className="mb-2 block">
-                {label}
-              </Label>
+            {(tooltip ?? label) && (
+              <div className="mb-2 flex gap-2">
+                {label && <Label htmlFor={id}>{label}</Label>}
+                {tooltip && (
+                  <FieldTooltip tooltip={tooltip} label={label} id={id} />
+                )}
+              </div>
             )}
             {render({
               ...states,

--- a/src/forms/Field/FieldTooltip.tsx
+++ b/src/forms/Field/FieldTooltip.tsx
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { Info } from 'lucide-react'
+import { Tooltip } from '@/components/Tooltip'
+import { type FieldProps } from '@/forms'
+import { ensureString } from '@/utils/misc'
+
+interface FieldTooltipProps extends Pick<FieldProps, 'tooltip' | 'label'> {
+  id: string
+}
+
+export const FieldTooltip = ({ tooltip, label, id }: FieldTooltipProps) => (
+  <Tooltip tooltip={tooltip} open={true}>
+    <button
+      type="button"
+      className="focus-ring rounded-md"
+      aria-label={[
+        'More information about the',
+        ensureString(label) ?? id,
+        'field',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <Info className="size-4 text-muted-foreground" />
+    </button>
+  </Tooltip>
+)

--- a/src/forms/Field/FieldTooltip.tsx
+++ b/src/forms/Field/FieldTooltip.tsx
@@ -7,16 +7,16 @@
 //
 
 import { Info } from 'lucide-react'
-import { Tooltip } from '@/components/Tooltip'
+import { Tooltip, type TooltipProps } from '@/components/Tooltip'
 import { type FieldProps } from '@/forms'
 import { ensureString } from '@/utils/misc'
 
-interface FieldTooltipProps extends Pick<FieldProps, 'tooltip' | 'label'> {
+interface FieldTooltipProps extends TooltipProps, Pick<FieldProps, 'label'> {
   id: string
 }
 
-export const FieldTooltip = ({ tooltip, label, id }: FieldTooltipProps) => (
-  <Tooltip tooltip={tooltip} open={true}>
+export const FieldTooltip = ({ label, id, ...props }: FieldTooltipProps) => (
+  <Tooltip {...props}>
     <button
       type="button"
       className="focus-ring rounded-md"


### PR DESCRIPTION
# Add Field tooltip

## :recycle: Current situation & Problem
Fields sometimes need more explanation about their purpose or details. Tooltips are useful for that. 


## :gear: Release Notes 
* Add Field tooltip

## :white_check_mark: Testing
![image](https://github.com/user-attachments/assets/719d0868-be44-4275-8c22-806e8b422933)


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
