### PR TITLE
Prevent returning empty string from getUserName function

### DIFF
--- a/src/modules/auth/user.test.ts
+++ b/src/modules/auth/user.test.ts
@@ -1,3 +1,11 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
 import { getUserName } from '@/modules/auth/user'
 
 describe('user', () => {

--- a/src/modules/auth/user.test.ts
+++ b/src/modules/auth/user.test.ts
@@ -1,0 +1,39 @@
+import { getUserName } from '@/modules/auth/user'
+
+describe('user', () => {
+  describe('getUserName', () => {
+    const johnUser = {
+      displayName: 'John Doe',
+      email: 'john@example.com',
+      uid: '1234-5678',
+    }
+
+    it('gets user name if defined', () => {
+      expect(getUserName(johnUser)).toBe(johnUser.displayName)
+    })
+
+    it('gets email if defined', () => {
+      expect(
+        getUserName({
+          ...johnUser,
+          displayName: null,
+        }),
+      ).toBe(johnUser.email)
+    })
+
+    it('gets uid if defined', () => {
+      expect(
+        getUserName({
+          ...johnUser,
+          displayName: null,
+          email: null,
+        }),
+      ).toBe(johnUser.uid)
+    })
+
+    it('responds with undefined or null if no property', () => {
+      expect(getUserName({})).toBe(undefined)
+      expect(getUserName({ uid: null })).toBe(null)
+    })
+  })
+})

--- a/src/modules/auth/user.ts
+++ b/src/modules/auth/user.ts
@@ -24,4 +24,6 @@ export const getUserName = (user: {
   displayName?: Nil<string>
   email?: Nil<string>
   uid?: Nil<string>
-}) => user.displayName ?? user.email ?? user.uid
+  // We want to exclude empty strings if possible
+  // eslint-disable-next-line
+}) => user.displayName || user.email || user.uid

--- a/src/modules/auth/user.ts
+++ b/src/modules/auth/user.ts
@@ -25,5 +25,5 @@ export const getUserName = (user: {
   email?: Nil<string>
   uid?: Nil<string>
   // We want to exclude empty strings if possible
-  // eslint-disable-next-line
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 }) => user.displayName || user.email || user.uid


### PR DESCRIPTION
# Prevent returning empty string from getUserName function

## :recycle: Current situation & Problem
Sometimes, `displayName` might be `""`. We want to make sure `getUserName` tries to provide whatever is renderable out of user object.


## :gear: Release Notes 
* Prevent returning empty string from getUserName function


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
