### PR TITLE
Publish package only after successful build

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -29,6 +29,7 @@ jobs:
     secrets: inherit
   publishpackage:
     name: Publish Package
+    needs: build-and-test
     uses: StanfordBDHG/.github/.github/workflows/npm-publish-package.yml@v2
     permissions:
       contents: read


### PR DESCRIPTION
# Publish package only after successful build

## :recycle: Current situation & Problem
Packages might be published before it went through all the necessary build and tests.


## :gear: Release Notes 
* Publish package only after successful build


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
