### PR TITLE
Add non-shrinkable variant of Dashboard

### DIFF
--- a/src/molecules/DashboardLayout/DashboardContext.tsx
+++ b/src/molecules/DashboardLayout/DashboardContext.tsx
@@ -1,0 +1,13 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { createContext } from "react";
+
+export const DashboardContext = createContext({
+  shrinkable: true,
+});

--- a/src/molecules/DashboardLayout/DashboardLayout.stories.tsx
+++ b/src/molecules/DashboardLayout/DashboardLayout.stories.tsx
@@ -8,6 +8,8 @@
 
 import { type Meta } from "@storybook/react";
 import { Home, User } from "lucide-react";
+import { type ComponentProps } from "react";
+import { cn } from "@/utils/className";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,7 +28,10 @@ const meta: Meta<typeof DashboardLayout> = {
 
 export default meta;
 
-export const Default = () => {
+const BaseComponent = ({
+  shrinkable = true,
+  ...props
+}: Partial<ComponentProps<typeof DashboardLayout>>) => {
   const user = (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -56,7 +61,14 @@ export const Default = () => {
           <span className="interactive-opacity w-full px-2 pt-4 text-center">
             Logo
           </span>
-          <nav className="mt-24 flex flex-col gap-1 xl:w-full">{menuLinks}</nav>
+          <nav
+            className={cn(
+              "mt-24 flex flex-col gap-1",
+              shrinkable ? "xl:w-full" : "lg:w-full",
+            )}
+          >
+            {menuLinks}
+          </nav>
           {user}
         </>
       }
@@ -67,8 +79,14 @@ export const Default = () => {
         </>
       }
       title={<PageTitle icon={<Home />} title="Home" />}
+      shrinkable={shrinkable}
+      {...props}
     >
       Content
     </DashboardLayout>
   );
 };
+
+export const Default = () => <BaseComponent />;
+
+export const NotShrinkable = () => <BaseComponent shrinkable={false} />;

--- a/src/molecules/DashboardLayout/DashboardLayout.tsx
+++ b/src/molecules/DashboardLayout/DashboardLayout.tsx
@@ -8,6 +8,7 @@
 
 import { Menu } from "lucide-react";
 import { type ReactNode } from "react";
+import { DashboardContext } from "@/molecules/DashboardLayout/DashboardContext";
 import { Button } from "../../components/Button";
 import { cn } from "../../utils/className";
 import { useOpenState } from "../../utils/useOpenState";
@@ -18,6 +19,11 @@ export interface DashboardLayoutProps {
   children?: ReactNode;
   aside?: ReactNode;
   mobile?: ReactNode;
+  /**
+   * Enables auto-shrink of dashboard's aside on lg screens. This optimizes real estate.
+   * @default true
+   * */
+  shrinkable?: boolean;
 }
 
 export const DashboardLayout = ({
@@ -26,48 +32,63 @@ export const DashboardLayout = ({
   children,
   aside,
   mobile,
+  shrinkable = true,
 }: DashboardLayoutProps) => {
   const menu = useOpenState();
 
   return (
-    <div className="text-foreground [--asideWidth:86px] [--headerHeight:72px] lg:[--headerHeight:86px] xl:[--asideWidth:240px] [&_*]:[box-sizing:border-box]">
-      <header
+    <DashboardContext.Provider value={{ shrinkable }}>
+      <div
         className={cn(
-          "border-b-border-layout flex h-[--headerHeight] items-center gap-4 border-x-0 border-b border-t-0 border-solid px-4 py-1 lg:ml-[--asideWidth] xl:px-8",
-          !title && !actions && "lg:hidden",
+          "text-foreground [--headerHeight:72px] lg:[--headerHeight:86px] [&_*]:[box-sizing:border-box]",
+          shrinkable ?
+            "[--asideWidth:86px] xl:[--asideWidth:240px]"
+          : "[--asideWidth:240px]",
         )}
       >
-        {title}
-        <div className="ml-auto gap-4">
-          {actions}
-          <Button
-            onClick={menu.toggle}
-            aria-label={`${menu.isOpen ? "Close" : "Open"} menu`}
-            className="ml-4 lg:hidden"
-          >
-            <Menu />
-          </Button>
+        <header
+          className={cn(
+            "border-b-border-layout flex h-[--headerHeight] items-center gap-4 border-x-0 border-b border-t-0 border-solid px-4 py-1 lg:ml-[--asideWidth] xl:px-8",
+            !title && !actions && "lg:hidden",
+          )}
+        >
+          {title}
+          <div className="ml-auto gap-4">
+            {actions}
+            <Button
+              onClick={menu.toggle}
+              aria-label={`${menu.isOpen ? "Close" : "Open"} menu`}
+              className="ml-4 lg:hidden"
+            >
+              <Menu />
+            </Button>
+          </div>
+        </header>
+        <aside
+          className={cn(
+            "border-r-border-layout fixed left-0 top-0 hidden h-screen w-[--asideWidth] flex-col items-center border-y-0 border-l-0 border-r border-solid bg-surface py-4 lg:flex",
+            shrinkable ? "xl:px-3" : "lg:px-3",
+          )}
+        >
+          {aside}
+        </aside>
+        <nav
+          className={cn(
+            "fixed left-0 right-0 top-[calc(var(--headerHeight)+1px)] flex h-[calc(100vh-var(--headerHeight)-1px)] w-screen flex-col overflow-y-auto bg-surface transition duration-300 lg:hidden",
+            menu.isOpen ? "z-10 translate-x-0" : (
+              "pointer-events-none -translate-x-24 opacity-0"
+            ),
+          )}
+          hidden={!menu.isOpen}
+          data-testid="mobileMenu"
+        >
+          {actions && <div className="p-4">{actions}</div>}
+          {mobile}
+        </nav>
+        <div className="flex min-h-[calc(100vh-var(--headerHeight))] flex-col px-4 pb-12 pt-6 md:px-12 md:pb-16 md:pt-10 lg:ml-[--asideWidth]">
+          {children}
         </div>
-      </header>
-      <aside className="border-r-border-layout fixed left-0 top-0 hidden h-screen w-[--asideWidth] flex-col items-center border-y-0 border-l-0 border-r border-solid bg-surface py-4 lg:flex xl:px-3">
-        {aside}
-      </aside>
-      <nav
-        className={cn(
-          "fixed left-0 right-0 top-[calc(var(--headerHeight)+1px)] flex h-[calc(100vh-var(--headerHeight)-1px)] w-screen flex-col overflow-y-auto bg-surface transition duration-300 lg:hidden",
-          menu.isOpen ? "z-10 translate-x-0" : (
-            "pointer-events-none -translate-x-24 opacity-0"
-          ),
-        )}
-        hidden={!menu.isOpen}
-        data-testid="mobileMenu"
-      >
-        {actions && <div className="p-4">{actions}</div>}
-        {mobile}
-      </nav>
-      <div className="flex min-h-[calc(100vh-var(--headerHeight))] flex-col px-4 pb-12 pt-6 md:px-12 md:pb-16 md:pt-10 lg:ml-[--asideWidth]">
-        {children}
       </div>
-    </div>
+    </DashboardContext.Provider>
   );
 };

--- a/src/molecules/DashboardLayout/DashboardLayout.tsx
+++ b/src/molecules/DashboardLayout/DashboardLayout.tsx
@@ -30,30 +30,25 @@ export const DashboardLayout = ({
   const menu = useOpenState();
 
   return (
-    <div
-      className={cn(
-        "text-foreground [--asideWidth:86px] xl:[--asideWidth:240px] [&_*]:[box-sizing:border-box]",
-        title ?
-          "[--headerHeight:72px] lg:[--headerHeight:86px]"
-        : "[--headerHeight:0px]",
-      )}
-    >
-      {title && (
-        <header className="border-b-border-layout flex h-[--headerHeight] items-center gap-4 border-x-0 border-b border-t-0 border-solid px-4 py-1 lg:ml-[--asideWidth] xl:px-8">
-          {title}
-          <div className="ml-auto gap-4">
-            {actions}
-            <Button
-              onClick={menu.toggle}
-              aria-label={`${menu.isOpen ? "Close" : "Open"} menu`}
-              className="ml-4 lg:hidden"
-            >
-              <Menu />
-            </Button>
-          </div>
-        </header>
-      )}
-
+    <div className="text-foreground [--asideWidth:86px] [--headerHeight:72px] lg:[--headerHeight:86px] xl:[--asideWidth:240px] [&_*]:[box-sizing:border-box]">
+      <header
+        className={cn(
+          "border-b-border-layout flex h-[--headerHeight] items-center gap-4 border-x-0 border-b border-t-0 border-solid px-4 py-1 lg:ml-[--asideWidth] xl:px-8",
+          !title && !actions && "lg:hidden",
+        )}
+      >
+        {title}
+        <div className="ml-auto gap-4">
+          {actions}
+          <Button
+            onClick={menu.toggle}
+            aria-label={`${menu.isOpen ? "Close" : "Open"} menu`}
+            className="ml-4 lg:hidden"
+          >
+            <Menu />
+          </Button>
+        </div>
+      </header>
       <aside className="border-r-border-layout fixed left-0 top-0 hidden h-screen w-[--asideWidth] flex-col items-center border-y-0 border-l-0 border-r border-solid bg-surface py-4 lg:flex xl:px-3">
         {aside}
       </aside>

--- a/src/molecules/DashboardLayout/MenuItem.tsx
+++ b/src/molecules/DashboardLayout/MenuItem.tsx
@@ -6,8 +6,9 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { type ReactNode } from "react";
+import { type ReactNode, useContext } from "react";
 import { useSpeziContext } from "@/SpeziProvider";
+import { DashboardContext } from "./DashboardContext";
 import { Tooltip } from "../../components/Tooltip";
 import { cn } from "../../utils/className";
 
@@ -17,6 +18,7 @@ interface MenuItemProps {
   isHighlighted?: boolean;
   icon?: ReactNode;
   label?: string;
+  children?: ReactNode;
 }
 
 export const MenuItem = ({
@@ -25,36 +27,53 @@ export const MenuItem = ({
   isActive,
   label,
   isHighlighted,
+  children,
 }: MenuItemProps) => {
+  const { shrinkable } = useContext(DashboardContext);
   const {
     router: { Link },
   } = useSpeziContext();
-  return (
-    <Tooltip
-      key={href}
-      tooltip={label}
-      sideOffset={8}
-      side="right"
-      className="hidden lg:block xl:hidden"
-    >
+
+  const content = (
+    <>
       <Link
         href={href}
         className={cn(
-          "focus-ring relative flex items-center gap-3 rounded-lg p-2 font-medium no-underline transition xl:w-full xl:self-start",
+          "focus-ring relative flex items-center gap-3 rounded-lg p-2 font-medium no-underline transition",
           isActive ?
             "bg-accent/50 text-primary hover:opacity-60"
           : "text-foreground/60 hover:bg-accent hover:text-foreground",
+          shrinkable ? "xl:w-full xl:self-start" : "lg:w-full lg:self-start",
         )}
       >
         {icon}
-        <span className="grow lg:hidden xl:block">{label}</span>
+        <span className={cn("grow", shrinkable && "lg:hidden xl:block")}>
+          {label}
+        </span>
+        {children}
         {isHighlighted && (
           <i
             aria-hidden
-            className="size-2.5 rounded-full bg-destructive lg:absolute lg:right-1 lg:top-1 lg:size-1.5 xl:static xl:size-2.5"
+            className={cn(
+              "size-2.5 rounded-full bg-destructive",
+              shrinkable &&
+                "lg:absolute lg:right-1 lg:top-1 lg:size-1.5 xl:static xl:size-2.5",
+            )}
           />
         )}
       </Link>
-    </Tooltip>
+    </>
   );
+
+  return shrinkable ?
+      <Tooltip
+        key={href}
+        tooltip={label}
+        sideOffset={8}
+        side="right"
+        className="hidden lg:block xl:hidden"
+      >
+        {content}
+      </Tooltip>
+    : content;
 };

--- a/src/molecules/DashboardLayout/UserMenuItem.tsx
+++ b/src/molecules/DashboardLayout/UserMenuItem.tsx
@@ -6,7 +6,9 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { forwardRef } from "react";
+import { forwardRef, useContext } from "react";
+import { cn } from "@/utils/className";
+import { DashboardContext } from "./DashboardContext";
 import { Avatar } from "../../components/Avatar";
 import { Button, type ButtonProps } from "../../components/Button";
 import { type Nil } from "../../utils/misc";
@@ -17,16 +19,28 @@ type UserMenuItemProps = Omit<ButtonProps, "name"> & {
 };
 
 export const UserMenuItem = forwardRef<HTMLButtonElement, UserMenuItemProps>(
-  ({ name, img, ...props }, ref) => (
-    <Button
-      variant="ghost"
-      className="mb-2 mt-auto !p-2 transition xl:mb-0 xl:w-full xl:justify-start xl:self-start"
-      ref={ref}
-      {...props}
-    >
-      <Avatar size="sm" name={name} src={img} />
-      <span className="truncate text-sm lg:hidden xl:block">{name}</span>
-    </Button>
-  ),
+  ({ name, img, ...props }, ref) => {
+    const { shrinkable } = useContext(DashboardContext);
+    return (
+      <Button
+        variant="ghost"
+        className={cn(
+          "mb-2 mt-auto !p-2 transition",
+          shrinkable ?
+            "xl:mb-0 xl:w-full xl:justify-start xl:self-start"
+          : "lg:mb-0 lg:w-full lg:justify-start lg:self-start",
+        )}
+        ref={ref}
+        {...props}
+      >
+        <Avatar size="sm" name={name} src={img} />
+        <span
+          className={cn("truncate text-sm", shrinkable && "lg:hidden xl:block")}
+        >
+          {name}
+        </span>
+      </Button>
+    );
+  },
 );
 UserMenuItem.displayName = "UserMenuItem";


### PR DESCRIPTION
# Add non-shrinkable variant of Dashboard

## :recycle: Current situation & Problem
`DashboardLayout` shrinks on smaller desktop screens to preserve more space. This works well for pure menus with icons, but doesn't if aside contains something else than `MenuLink`. 


## :gear: Release Notes
* Add non-shrinkable variant of Dashboard
`shrinkable={false}` property
* Fix hiding header. 
If there is no title and actions, hide header, but only on desktops. On mobile screens we still need it to open menu.

https://github.com/user-attachments/assets/e14b57cf-71fb-4de5-b11d-859071e459ed

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
