### PR TITLE
Fix flaky Calendar tests

### DIFF
--- a/src/components/Calendar/Calendar.test.tsx
+++ b/src/components/Calendar/Calendar.test.tsx
@@ -14,7 +14,14 @@ describe("Calendar", () => {
   it("renders calendar", () => {
     const date = new Date(2024, 6, 27);
     const onSelect = vitest.fn();
-    render(<Calendar mode="single" selected={date} onSelect={onSelect} />);
+    render(
+      <Calendar
+        defaultMonth={date}
+        mode="single"
+        selected={date}
+        onSelect={onSelect}
+      />,
+    );
 
     const goToPrevMonth = screen.getByRole("button", {
       name: "Go to previous month",


### PR DESCRIPTION
# Fix flaky Calendar tests

## :recycle: Current situation & Problem
`Calendar` tests are failing due to short month of February. In order to fix it, make sure displayed month is the same as `selected` date.


## :gear: Release Notes
* Fix flaky Calendar tests


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
