### PR TITLE
Add InputOTP component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "date-fns": "^3.6.0",
         "es-toolkit": "^1.32.0",
         "firebase": "^11.2.0",
+        "input-otp": "^1.4.2",
         "lucide-react": "^0.474.0",
         "react-day-picker": "^8",
         "react-hook-form": "^7.54.2",
@@ -8106,6 +8107,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/input-otp": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
+      "integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -262,6 +262,7 @@
     "date-fns": "^3.6.0",
     "es-toolkit": "^1.32.0",
     "firebase": "^11.2.0",
+    "input-otp": "^1.4.2",
     "lucide-react": "^0.474.0",
     "react-day-picker": "^8",
     "react-hook-form": "^7.54.2",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,10 @@
       "types": "./dist/components/Input.d.ts",
       "default": "./dist/components/Input.js"
     },
+    "./components/InputOTP": {
+      "types": "./dist/components/InputOTP.d.ts",
+      "default": "./dist/components/InputOTP.js"
+    },
     "./components/Label": {
       "types": "./dist/components/Label.d.ts",
       "default": "./dist/components/Label.js"

--- a/src/components/InputOTP/InputOTP.stories.tsx
+++ b/src/components/InputOTP/InputOTP.stories.tsx
@@ -1,0 +1,45 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { type Meta, type StoryObj } from "@storybook/react";
+import { Input } from "@/components/Input";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPRoot,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "./InputOTP";
+
+const meta: Meta<typeof InputOTP> = {
+  title: "Components/InputOTP",
+  component: InputOTP,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof InputOTP>;
+
+export const Default: Story = { args: { maxLength: 6 } };
+
+export const Custom = () => (
+  <div className="flex gap-2">
+    <Input />
+    <InputOTPRoot maxLength={4}>
+      <InputOTPGroup>
+        <InputOTPSlot index={0} />
+        <InputOTPSlot index={1} />
+      </InputOTPGroup>
+      <InputOTPSeparator />
+      <InputOTPGroup>
+        <InputOTPSlot index={2} />
+        <InputOTPSlot index={3} />
+      </InputOTPGroup>
+    </InputOTPRoot>
+  </div>
+);

--- a/src/components/InputOTP/InputOTP.stories.tsx
+++ b/src/components/InputOTP/InputOTP.stories.tsx
@@ -7,7 +7,6 @@
 //
 
 import { type Meta, type StoryObj } from "@storybook/react";
-import { Input } from "@/components/Input";
 import {
   InputOTP,
   InputOTPGroup,
@@ -28,18 +27,15 @@ type Story = StoryObj<typeof InputOTP>;
 export const Default: Story = { args: { maxLength: 6 } };
 
 export const Custom = () => (
-  <div className="flex gap-2">
-    <Input />
-    <InputOTPRoot maxLength={4}>
-      <InputOTPGroup>
-        <InputOTPSlot index={0} />
-        <InputOTPSlot index={1} />
-      </InputOTPGroup>
-      <InputOTPSeparator />
-      <InputOTPGroup>
-        <InputOTPSlot index={2} />
-        <InputOTPSlot index={3} />
-      </InputOTPGroup>
-    </InputOTPRoot>
-  </div>
+  <InputOTPRoot maxLength={4}>
+    <InputOTPGroup>
+      <InputOTPSlot index={0} />
+      <InputOTPSlot index={1} />
+    </InputOTPGroup>
+    <InputOTPSeparator />
+    <InputOTPGroup>
+      <InputOTPSlot index={2} />
+      <InputOTPSlot index={3} />
+    </InputOTPGroup>
+  </InputOTPRoot>
 );

--- a/src/components/InputOTP/InputOTP.test.tsx
+++ b/src/components/InputOTP/InputOTP.test.tsx
@@ -1,0 +1,27 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { InputOTP } from ".";
+
+describe("InputOTP", () => {
+  it("renders otp input", () => {
+    render(<InputOTP maxLength={6} />);
+
+    const textBox = screen.getByRole("textbox", { hidden: true });
+    expect(textBox).toBeInTheDocument();
+
+    const value = "123";
+
+    fireEvent.change(textBox, { target: { value } });
+
+    value.split("").forEach((number) => {
+      expect(screen.getByText(number)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/InputOTP/InputOTP.tsx
+++ b/src/components/InputOTP/InputOTP.tsx
@@ -80,7 +80,7 @@ export const InputOTPSeparator = forwardRef<
 InputOTPSeparator.displayName = "InputOTPSeparator";
 
 /**
- * Accessible one-time password component.
+ * Accessible one time password input.
  * InputOTP renders maxLength of slots for your secret - see Components/InputOTP#Default story
  * If you need to customize rendering - see Components/InputOTP#Custom story
  * */

--- a/src/components/InputOTP/InputOTP.tsx
+++ b/src/components/InputOTP/InputOTP.tsx
@@ -1,0 +1,99 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { OTPInput, OTPInputContext } from "input-otp";
+import { Minus } from "lucide-react";
+import {
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  forwardRef,
+  useContext,
+} from "react";
+import { cn } from "@/utils/className";
+import { times } from "@/utils/misc";
+
+export const InputOTPRoot = forwardRef<
+  ElementRef<typeof OTPInput>,
+  ComponentPropsWithoutRef<typeof OTPInput>
+>(({ className, containerClassName, ...props }, ref) => (
+  <OTPInput
+    ref={ref}
+    containerClassName={cn(
+      "flex items-center gap-1.5 has-[:disabled]:opacity-50",
+      containerClassName,
+    )}
+    className={cn("disabled:cursor-not-allowed", className)}
+    {...props}
+  />
+));
+InputOTPRoot.displayName = "InputOTPRoot";
+
+export const InputOTPGroup = forwardRef<
+  ElementRef<"div">,
+  ComponentPropsWithoutRef<"div">
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center", className)} {...props} />
+));
+InputOTPGroup.displayName = "InputOTPGroup";
+
+export const InputOTPSlot = forwardRef<
+  ElementRef<"div">,
+  ComponentPropsWithoutRef<"div"> & { index: number }
+>(({ index, className, ...props }, ref) => {
+  const inputOTPContext = useContext(OTPInputContext);
+  const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index];
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "flex-center relative size-10 border-y border-r border-input text-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md",
+        isActive && "z-10 ring-2 ring-ring",
+        className,
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="flex-center pointer-events-none absolute inset-0">
+          <div className="animate-caret-blink h-4 w-px bg-foreground duration-1000" />
+        </div>
+      )}
+    </div>
+  );
+});
+InputOTPSlot.displayName = "InputOTPSlot";
+
+export const InputOTPSeparator = forwardRef<
+  ElementRef<"div">,
+  ComponentPropsWithoutRef<"div">
+>(({ ...props }, ref) => (
+  <div ref={ref} role="separator" {...props}>
+    <Minus className="w-4 text-muted-foreground" />
+  </div>
+));
+InputOTPSeparator.displayName = "InputOTPSeparator";
+
+/**
+ * Accessible one-time password component.
+ * InputOTP renders maxLength of slots for your secret - see Components/InputOTP#Default story
+ * If you need to customize rendering - see Components/InputOTP#Custom story
+ * */
+export const InputOTP = forwardRef<
+  ElementRef<typeof OTPInput>,
+  Omit<ComponentPropsWithoutRef<typeof OTPInput>, "render">
+>(({ maxLength, ...props }, ref) => (
+  <InputOTPRoot maxLength={maxLength} ref={ref} {...props}>
+    <InputOTPGroup>
+      {times(maxLength, (index) => (
+        <InputOTPSlot index={index} key={index} />
+      ))}
+    </InputOTPGroup>
+  </InputOTPRoot>
+));
+InputOTPRoot.displayName = "InputOTP";

--- a/src/components/InputOTP/index.tsx
+++ b/src/components/InputOTP/index.tsx
@@ -6,12 +6,4 @@
 // SPDX-License-Identifier: MIT
 //
 
-import "@testing-library/jest-dom";
-
-const ResizeObserverMock = vi.fn(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}));
-
-vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+export * from "./InputOTP";

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export * from "./components/DropdownMenu";
 export * from "./components/EmptyState";
 export * from "./components/Error";
 export * from "./components/Input";
+export * from "./components/InputOTP";
 export * from "./components/Label";
 export * from "./components/Pagination";
 export * from "./components/Popover";


### PR DESCRIPTION
# Add InputOTP component

## :recycle: Current situation & Problem
InputOTP is useful for handling one time passwords, confirmation codes and secrets.

## :gear: Release Notes
* Add InputOTP component

```ts
<InputOTP
  maxLength={8}
  onComplete={(code: string) => {}}
/>
```

![image](https://github.com/user-attachments/assets/f5696451-fd10-4bcd-af58-c405b58d8785)


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
