### PR TITLE
Make empty state of DataTable customizable

### DIFF
--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -119,6 +119,38 @@ export const CustomView = () => (
   </DataTable>
 );
 
+export const Loading: Story = {
+  args: {
+    ...Default.args,
+    data: [],
+    loading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    ...Default.args,
+    data: [],
+  },
+};
+
+export const CustomizedEmptyMessage: Story = {
+  args: {
+    ...Default.args,
+    data: [],
+    empty: {
+      children: "Sorry, no users found. Please try again later.",
+    },
+  },
+};
+
+export const Error: Story = {
+  args: {
+    ...Default.args,
+    error: true,
+  },
+};
+
 export const Minimal: Story = {
   args: {
     ...Default.args,

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -59,6 +59,16 @@ describe("DataTable", () => {
     );
     const emptyStateWithEntityName = screen.getByText(/No\susers\sfound/);
     expect(emptyStateWithEntityName).toBeInTheDocument();
+
+    rerender(
+      <DataTable
+        columns={peopleColumns}
+        data={[]}
+        empty={{ children: "Custom error message" }}
+      />,
+    );
+    const customEmptyState = screen.getByText("Custom error message");
+    expect(customEmptyState).toBeInTheDocument();
   });
 
   it("paginates data", () => {

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -47,28 +47,38 @@ describe("DataTable", () => {
     expect(someCell).toBeInTheDocument();
   });
 
-  it("shows empty state", () => {
-    const { rerender } = render(
-      <DataTable columns={peopleColumns} data={[]} />,
-    );
+  describe("empty state", () => {
+    it("shows default empty state", () => {
+      render(<DataTable columns={peopleColumns} data={[]} />);
 
-    expectEmptyStateToBeInTheDocument();
+      expectEmptyStateToBeInTheDocument();
+    });
 
-    rerender(
-      <DataTable columns={peopleColumns} data={[]} entityName="users" />,
-    );
-    const emptyStateWithEntityName = screen.getByText(/No\susers\sfound/);
-    expect(emptyStateWithEntityName).toBeInTheDocument();
+    it("shows entityName", () => {
+      render(
+        <DataTable columns={peopleColumns} data={[]} entityName="users" />,
+      );
+      const emptyStateWithEntityName = screen.getByText(/No\susers\sfound/);
+      expect(emptyStateWithEntityName).toBeInTheDocument();
+    });
 
-    rerender(
-      <DataTable
-        columns={peopleColumns}
-        data={[]}
-        empty={{ children: "Custom error message" }}
-      />,
-    );
-    const customEmptyState = screen.getByText("Custom error message");
-    expect(customEmptyState).toBeInTheDocument();
+    it("shows customized messages", () => {
+      render(
+        <DataTable
+          columns={peopleColumns}
+          data={[]}
+          empty={{ children: "Custom error message" }}
+        />,
+      );
+      const customEmptyState = screen.getByText("Custom error message");
+      expect(customEmptyState).toBeInTheDocument();
+    });
+
+    it("shows no error state if empty overrides default checks", () => {
+      render(<DataTable columns={peopleColumns} data={[]} empty={false} />);
+      const emptyState = screen.queryByText(/No\sdata\sfound/);
+      expect(emptyState).not.toBeInTheDocument();
+    });
   });
 
   it("paginates data", () => {

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -28,9 +28,13 @@ describe("DataTable", () => {
       expect(cellColumn).toBeInTheDocument();
     });
 
-  const expectEmptyStateToBeInTheDocument = () => {
+  const queryEmptyState = () => {
     // Regex because text is broken with elements
-    const emptyState = screen.getByText(/No\sdata\sfound/);
+    return screen.queryByText(/No\sdata\sfound/);
+  };
+
+  const expectEmptyStateToBeInTheDocument = () => {
+    const emptyState = queryEmptyState();
     expect(emptyState).toBeInTheDocument();
   };
 
@@ -72,11 +76,13 @@ describe("DataTable", () => {
       );
       const customEmptyState = screen.getByText("Custom error message");
       expect(customEmptyState).toBeInTheDocument();
+      const defaultEmptyState = queryEmptyState();
+      expect(defaultEmptyState).not.toBeInTheDocument();
     });
 
     it("shows no error state if empty overrides default checks", () => {
       render(<DataTable columns={peopleColumns} data={[]} empty={false} />);
-      const emptyState = screen.queryByText(/No\sdata\sfound/);
+      const emptyState = queryEmptyState();
       expect(emptyState).not.toBeInTheDocument();
     });
   });

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -7,6 +7,7 @@
 //
 
 import { type Row, type Table as TableType } from "@tanstack/table-core";
+import { isBoolean } from "es-toolkit";
 import { type ReactNode } from "react";
 import {
   Async,
@@ -111,10 +112,9 @@ export const DataTable = <Data,>({
         entityName={entityName}
         empty={
           isObject(empty) ? { ...defaultEmptyProps, ...empty }
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          : empty === undefined ?
-            defaultEmptyProps
-          : empty
+          : isBoolean(empty) ?
+            empty
+          : defaultEmptyProps
         }
       >
         {children ?

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -8,12 +8,16 @@
 
 import { type Row, type Table as TableType } from "@tanstack/table-core";
 import { type ReactNode } from "react";
-import { Async, type AsyncProps } from "@/components/Async/Async";
+import {
+  Async,
+  type AsyncProps,
+  type FullEmptyProps,
+} from "@/components/Async/Async";
 import {
   DataTableTableView,
   type DataTableTableViewSpecificProps,
 } from "@/components/DataTable/DataTableTableView";
-import { ensureString } from "@/utils/misc";
+import { ensureString, isObject } from "@/utils/misc";
 import { useDataTable, type UseDataTableProps } from "./DataTable.utils";
 import { DataTablePagination } from "./DataTablePagination";
 import { GlobalFilterInput } from "./GlobalFilterInput";
@@ -48,6 +52,7 @@ export interface DataTableProps<Data>
    * */
   minimal?: boolean;
   tableView?: DataTableTableViewSpecificProps<Data>;
+  empty?: boolean | Partial<FullEmptyProps>;
 }
 
 export const DataTable = <Data,>({
@@ -63,6 +68,7 @@ export const DataTable = <Data,>({
   tableView,
   loading = false,
   error = false,
+  empty,
   ...props
 }: DataTableProps<Data>) => {
   const { table, setGlobalFilterDebounced } = useDataTable({
@@ -75,6 +81,8 @@ export const DataTable = <Data,>({
 
   const isEmpty = !rows.length;
   const viewProps = { table, entityName, rows };
+
+  const emptyParams = isObject(empty) ? empty : {};
 
   return (
     <div
@@ -102,6 +110,7 @@ export const DataTable = <Data,>({
           textFilter: ensureString(table.getState().globalFilter),
           hasFilters:
             data.length !== 0 && table.getState().columnFilters.length > 0,
+          ...emptyParams,
         }}
       >
         {children ?

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -82,7 +82,11 @@ export const DataTable = <Data,>({
   const isEmpty = !rows.length;
   const viewProps = { table, entityName, rows };
 
-  const emptyParams = isObject(empty) ? empty : {};
+  const defaultEmptyProps = {
+    show: rows.length === 0,
+    textFilter: ensureString(table.getState().globalFilter),
+    hasFilters: data.length !== 0 && table.getState().columnFilters.length > 0,
+  };
 
   return (
     <div
@@ -105,13 +109,13 @@ export const DataTable = <Data,>({
         error={error}
         loading={loading}
         entityName={entityName}
-        empty={{
-          show: rows.length === 0,
-          textFilter: ensureString(table.getState().globalFilter),
-          hasFilters:
-            data.length !== 0 && table.getState().columnFilters.length > 0,
-          ...emptyParams,
-        }}
+        empty={
+          isObject(empty) ? { ...defaultEmptyProps, ...empty }
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          : empty === undefined ?
+            defaultEmptyProps
+          : empty
+        }
       >
         {children ?
           children(viewProps)


### PR DESCRIPTION
# Make empty state of DataTable customizable

## :recycle: Current situation & Problem
`DataTable` handles empty props internally. This PR adds way to customize default DataTable approach.


## :gear: Release Notes
* Add customizable empty state to DataTable
* Add more state stories
* Restructure empty state tests

![image](https://github.com/user-attachments/assets/7d1b3630-c3f9-45df-8b8e-a322a0b5dd8c)



## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
