### PR TITLE
Add Skeleton component

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,10 @@
       "types": "./dist/components/Separator.d.ts",
       "default": "./dist/components/Separator.js"
     },
+    "./components/Skeleton": {
+      "types": "./dist/components/Skeleton.d.ts",
+      "default": "./dist/components/Skeleton.js"
+    },
     "./components/SideLabel": {
       "types": "./dist/components/SideLabel.d.ts",
       "default": "./dist/components/SideLabel.js"

--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,25 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { type Meta, type StoryObj } from "@storybook/react";
+import { Skeleton } from "./Skeleton";
+
+const meta: Meta<typeof Skeleton> = {
+  title: "Components/Skeleton",
+  component: Skeleton,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = { args: { style: { width: 400, height: 60 } } };
+
+export const Rounded: Story = {
+  args: { style: { width: 40, height: 40 }, round: true },
+};

--- a/src/components/Skeleton/Skeleton.test.tsx
+++ b/src/components/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,21 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { render, screen } from "@testing-library/react";
+import { Skeleton } from ".";
+
+describe("Skeleton", () => {
+  it("renders empty decorative skeleton element", () => {
+    render(<Skeleton data-testid="skeleton" />);
+
+    const element = screen.getByTestId("skeleton");
+
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveTextContent("");
+  });
+});

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,32 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { type ComponentProps } from "react";
+import { cn } from "@/utils/className";
+
+type SkeletonProps = ComponentProps<"div"> & {
+  /**
+   * Full circle skeleton
+   * */
+  round?: boolean;
+};
+/**
+ * Skeleton to indicate content loading state.
+ * Useful if you load data partially and want to preserve layout size.
+ * */
+export const Skeleton = ({ className, round, ...props }: SkeletonProps) => (
+  <div
+    className={cn(
+      "animate-pulse bg-accent",
+      round ? "rounded-full" : "rounded-md",
+      className,
+    )}
+    aria-hidden={true}
+    {...props}
+  />
+);

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -15,6 +15,7 @@ type SkeletonProps = ComponentProps<"div"> & {
    * */
   round?: boolean;
 };
+
 /**
  * Skeleton to indicate content loading state.
  * Useful if you load data partially and want to preserve layout size.

--- a/src/components/Skeleton/index.tsx
+++ b/src/components/Skeleton/index.tsx
@@ -1,0 +1,9 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+export * from "./Skeleton";

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export * from "./components/Badge";
 export * from "./components/Spinner";
 export * from "./components/Async";
 export * from "./components/StateContainer";
+export * from "./components/Skeleton";
 export * from "./forms/useForm";
 export * from "./forms/Field";
 export * from "./forms/FormError";


### PR DESCRIPTION
# Add Skeleton component

## :recycle: Current situation & Problem
`Skeleton` is a loading state pattern that allows rendering "loader" in a shape of the actual content, to prevent layout shifts.


## :gear: Release Notes
* Add "Skeleton" component


https://github.com/user-attachments/assets/1bcca124-94c8-462d-b9f5-12c670b40183




## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
