### PR TITLE
Add new elements to Popover component

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -12,14 +12,14 @@ import { type ComponentProps } from "react";
 import { cn } from "../../utils/className";
 import { Button } from "../Button";
 import { Calendar } from "../Calendar";
-import { Popover, PopoverTrigger, PopoverContent } from "../Popover";
+import { PopoverRoot, PopoverTrigger, PopoverContent } from "../Popover";
 
 export type DatePickerProps = ComponentProps<typeof Calendar>;
 
 export const DatePicker = (props: DatePickerProps) => {
   const { selected, showTimePicker } = props;
   return (
-    <Popover>
+    <PopoverRoot>
       <PopoverTrigger asChild>
         <Button
           variant="outline"
@@ -37,6 +37,6 @@ export const DatePicker = (props: DatePickerProps) => {
       <PopoverContent className="!w-auto !p-0">
         <Calendar {...props} />
       </PopoverContent>
-    </Popover>
+    </PopoverRoot>
   );
 };

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -7,18 +7,25 @@
 //
 
 import { type Meta } from "@storybook/react";
-import { Popover, PopoverContent, PopoverTrigger } from "./Popover";
+import { PopoverRoot, PopoverContent, PopoverTrigger } from "./Popover";
 
-const meta: Meta<typeof Popover> = {
+const meta: Meta<typeof PopoverRoot> = {
   title: "Components/Popover",
-  component: Popover,
+  component: PopoverRoot,
 };
 
 export default meta;
 
 export const Default = () => (
-  <Popover>
+  <PopoverRoot>
     <PopoverTrigger>Trigger</PopoverTrigger>
     <PopoverContent>Content</PopoverContent>
-  </Popover>
+  </PopoverRoot>
+);
+
+export const Arrow = () => (
+  <PopoverRoot>
+    <PopoverTrigger>Trigger</PopoverTrigger>
+    <PopoverContent arrow>Content</PopoverContent>
+  </PopoverRoot>
 );

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -7,7 +7,15 @@
 //
 
 import { type Meta } from "@storybook/react";
-import { PopoverRoot, PopoverContent, PopoverTrigger } from "./Popover";
+import {
+  PopoverRoot,
+  PopoverContent,
+  PopoverTrigger,
+  PopoverCloseX,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+} from "./Popover";
 
 const meta: Meta<typeof PopoverRoot> = {
   title: "Components/Popover",
@@ -27,5 +35,30 @@ export const Arrow = () => (
   <PopoverRoot>
     <PopoverTrigger>Trigger</PopoverTrigger>
     <PopoverContent arrow>Content</PopoverContent>
+  </PopoverRoot>
+);
+
+export const Close = () => (
+  <PopoverRoot>
+    <PopoverTrigger>Trigger</PopoverTrigger>
+    <PopoverContent>
+      Content
+      <PopoverCloseX />
+    </PopoverContent>
+  </PopoverRoot>
+);
+
+export const Header = () => (
+  <PopoverRoot>
+    <PopoverTrigger>Trigger</PopoverTrigger>
+    <PopoverContent>
+      <PopoverHeader>
+        <PopoverTitle>Lorem ipsum</PopoverTitle>
+        <PopoverDescription>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam
+          architecto asperiores atque consectetur.
+        </PopoverDescription>
+      </PopoverHeader>
+    </PopoverContent>
   </PopoverRoot>
 );

--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -7,15 +7,15 @@
 //
 
 import { fireEvent, render, screen } from "@testing-library/react";
-import { Popover, PopoverTrigger, PopoverContent } from ".";
+import { PopoverRoot, PopoverTrigger, PopoverContent } from ".";
 
 describe("Popover", () => {
   it("renders accessible popover", async () => {
     render(
-      <Popover>
+      <PopoverRoot>
         <PopoverTrigger>Trigger</PopoverTrigger>
         <PopoverContent>Content</PopoverContent>
-      </Popover>,
+      </PopoverRoot>,
     );
 
     const dialog = screen.queryByRole("dialog");

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -7,7 +7,9 @@
 //
 
 import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { X } from "lucide-react";
 import {
+  type ComponentProps,
   type ComponentPropsWithoutRef,
   type ElementRef,
   forwardRef,
@@ -19,6 +21,37 @@ export const PopoverRoot = PopoverPrimitive.Root;
 export const PopoverTrigger = PopoverPrimitive.Trigger;
 
 export const PopoverArrow = PopoverPrimitive.Arrow;
+
+export const PopoverHeader = ({
+  className,
+  ...props
+}: ComponentProps<"div">) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+
+export const PopoverTitle = ({ className, ...props }: ComponentProps<"h6">) => (
+  <h6 className={cn("text-lg font-semibold", className)} {...props} />
+);
+
+export const PopoverDescription = ({
+  className,
+  ...props
+}: ComponentProps<"h6">) => (
+  <p className={cn("text-sm text-muted-foreground", className)} {...props} />
+);
+
+export const PopoverCloseX = () => (
+  <PopoverPrimitive.Close className="ring-offset-background absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+    <X className="size-4" />
+    <span className="sr-only">Close</span>
+  </PopoverPrimitive.Close>
+);
 
 type PopoverContentProps = ComponentPropsWithoutRef<
   typeof PopoverPrimitive.Content

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -14,25 +14,41 @@ import {
 } from "react";
 import { cn } from "../../utils/className";
 
-export const Popover = PopoverPrimitive.Root;
+export const PopoverRoot = PopoverPrimitive.Root;
 
 export const PopoverTrigger = PopoverPrimitive.Trigger;
 
+export const PopoverArrow = PopoverPrimitive.Arrow;
+
+type PopoverContentProps = ComponentPropsWithoutRef<
+  typeof PopoverPrimitive.Content
+> & { arrow?: boolean };
+
 export const PopoverContent = forwardRef<
   ElementRef<typeof PopoverPrimitive.Content>,
-  ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow outline-none",
-        className,
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-));
+  PopoverContentProps
+>(
+  (
+    { className, children, align = "center", sideOffset = 4, arrow, ...props },
+    ref,
+  ) => (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow outline-none",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {arrow && (
+          <PopoverArrow className="fill-popover" width={12} height={8} />
+        )}
+      </PopoverPrimitive.Content>
+    </PopoverPrimitive.Portal>
+  ),
+);
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;


### PR DESCRIPTION
# Add new elements to Popover component

## :recycle: Current situation & Problem
Popover was very basic compared to Dialog. Since they can serve similar purpose, I added similar tooling around Popover as in the Dialog. 


## :gear: Release Notes
* Add arrow to Popover
* Add PopoverTitle, PopoverDescription,PopoverCloseX components

https://github.com/user-attachments/assets/6a9766f9-061f-4c25-a260-0548c0b61c40

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
