### PR TITLE
Add different Dialog sizes

### DIFF
--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -6,7 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { type Meta } from "@storybook/react";
+import { type Meta, type StoryObj } from "@storybook/react";
+import { type Size, sizes } from "@/utils/tailwind/helpers";
 import { Button } from "../Button";
 import {
   Dialog,
@@ -18,18 +19,16 @@ import {
   DialogTrigger,
 } from ".";
 
-const meta: Meta = {
-  title: "Components/Dialog",
-};
+interface FullDialogProps {
+  size?: Size;
+}
 
-export default meta;
-
-export const Default = () => (
+const FullDialog = ({ size }: FullDialogProps) => (
   <Dialog>
     <DialogTrigger asChild>
       <Button>Trigger</Button>
     </DialogTrigger>
-    <DialogContent>
+    <DialogContent size={size}>
       <DialogHeader>
         <DialogTitle>Lorem ipsum</DialogTitle>
         <DialogDescription>
@@ -52,3 +51,39 @@ export const Default = () => (
     </DialogContent>
   </Dialog>
 );
+
+const meta = {
+  title: "Components/Dialog",
+  component: FullDialog,
+  args: {
+    size: "lg",
+  },
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: sizes,
+    },
+  },
+} satisfies Meta<typeof FullDialog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+const createMaxWidthStory = (size: Size): Story => ({
+  args: { size },
+});
+
+export const SizeXs = createMaxWidthStory("xs");
+export const SizeSm = createMaxWidthStory("sm");
+export const SizeMd = createMaxWidthStory("md");
+export const SizeLg = createMaxWidthStory("lg");
+export const SizeXl = createMaxWidthStory("xl");
+export const Size2xl = createMaxWidthStory("2xl");
+export const Size3xl = createMaxWidthStory("3xl");
+export const Size4xl = createMaxWidthStory("4xl");
+export const Size5xl = createMaxWidthStory("5xl");
+export const Size6xl = createMaxWidthStory("6xl");
+export const Size7xl = createMaxWidthStory("7xl");

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -14,6 +14,7 @@ import {
   forwardRef,
   type HTMLAttributes,
 } from "react";
+import { type Size, sizeToMaxWidthRecord } from "@/utils/tailwind/helpers";
 import { cn } from "../../utils/className";
 
 export const Dialog = DialogPrimitive.Root;
@@ -39,16 +40,26 @@ export const DialogOverlay = forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+interface DialogContentProps
+  extends ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  /**
+   * Determines maximum width of the modal
+   * */
+  size?: Size | null;
+}
+
 export const DialogContent = forwardRef<
   ElementRef<typeof DialogPrimitive.Content>,
-  ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(({ className, children, size = "lg", ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-surface p-6 shadow-lg duration-200 sm:rounded-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+        "fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-surface p-6 shadow-lg duration-200 sm:rounded-lg",
+        size && sizeToMaxWidthRecord[size],
         className,
       )}
       {...props}

--- a/src/utils/tailwind/helpers.ts
+++ b/src/utils/tailwind/helpers.ts
@@ -32,3 +32,5 @@ export const sizeToMaxWidthRecord: Record<Size, string> = {
   "6xl": "max-w-6xl",
   "7xl": "max-w-7xl",
 };
+
+export const sizes = Object.keys(sizeToMaxWidthRecord);

--- a/src/utils/tailwind/helpers.ts
+++ b/src/utils/tailwind/helpers.ts
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+export type Size =
+  | "xs"
+  | "sm"
+  | "md"
+  | "lg"
+  | "xl"
+  | "2xl"
+  | "3xl"
+  | "4xl"
+  | "5xl"
+  | "6xl"
+  | "7xl";
+
+export const sizeToMaxWidthRecord: Record<Size, string> = {
+  xs: "max-w-xs",
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-xl",
+  "2xl": "max-w-2xl",
+  "3xl": "max-w-3xl",
+  "4xl": "max-w-4xl",
+  "5xl": "max-w-5xl",
+  "6xl": "max-w-6xl",
+  "7xl": "max-w-7xl",
+};


### PR DESCRIPTION
# Add different Dialog sizes

## :recycle: Current situation & Problem
Currently changing Dialog size requires overwriting default `max-w-lg`. Dialog size change is quite common operation, so it's handy to create and surface special prop for that


## :gear: Release Notes
* Create Tailwind size helpers
* Add `size` prop to Dialog
* Add stories for size dialogs


https://github.com/user-attachments/assets/9597e43f-3691-4452-9252-dc3eca246dab


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
