### PR TITLE
Expose LabelContainer as separate component

### DIFF
--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -21,3 +21,12 @@ export const Label = ({ className, ...props }: LabelProps) => (
     {...props}
   />
 );
+
+type LabelContainerProps = ComponentProps<"div">;
+
+export const LabelContainer = ({
+  className,
+  ...props
+}: LabelContainerProps) => (
+  <div className={cn("mb-2 flex gap-2", className)} {...props} />
+);

--- a/src/forms/Field/Field.stories.tsx
+++ b/src/forms/Field/Field.stories.tsx
@@ -8,6 +8,7 @@
 
 import { type Meta } from "@storybook/react";
 import { z } from "zod";
+import { LabelContainer, Label as LabelComponent } from "@/components/Label";
 import { Field } from "./Field";
 import { Input } from "../../components/Input";
 import { useForm } from "../useForm";
@@ -75,6 +76,27 @@ export const Tooltip = () => {
       label="Name"
       tooltip="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
       render={({ field }) => <Input {...field} />}
+    />
+  );
+};
+
+export const CustomLabelElements = () => {
+  const form = useForm({ formSchema });
+  return (
+    <Field
+      control={form.control}
+      name="name"
+      render={({ field }) => (
+        <>
+          <LabelContainer className="items-center justify-between">
+            <LabelComponent htmlFor="name">Name</LabelComponent>
+            <a href="/" className="text-xs underline">
+              Custom link
+            </a>
+          </LabelContainer>
+          <Input {...field} />
+        </>
+      )}
     />
   );
 };

--- a/src/forms/Field/Field.tsx
+++ b/src/forms/Field/Field.tsx
@@ -17,9 +17,9 @@ import {
   type FieldValues,
   type UseFormStateReturn,
 } from "react-hook-form";
+import { Error } from "@/components/Error";
+import { Label, LabelContainer } from "@/components/Label";
 import { FieldTooltip } from "./FieldTooltip";
-import { Error } from "../../components/Error";
-import { Label } from "../../components/Label";
 
 export type FieldProps<
   TFieldValues extends FieldValues = FieldValues,
@@ -81,12 +81,12 @@ export const Field = <
         return (
           <div className={className}>
             {tooltip || label ?
-              <div className="mb-2 flex gap-2">
+              <LabelContainer>
                 {label && <Label htmlFor={id}>{label}</Label>}
                 {tooltip && (
                   <FieldTooltip tooltip={tooltip} label={label} id={id} />
                 )}
-              </div>
+              </LabelContainer>
             : null}
             {render({
               ...states,


### PR DESCRIPTION
# Expose LabelContainer as separate component

## :recycle: Current situation & Problem
Sometimes there is a need to customize label rendering, by adding new properties, but keeping standard label<->form field distance and gaps between label elements. Exposed `LabelContainer` allows that.


## :gear: Release Notes
* Expose LabelContainer as separate component


## :white_check_mark: Testing
Nothing changed implementation wise.

**Custom Label Elements** story

![image](https://github.com/user-attachments/assets/9ce6176d-533b-492e-8d4d-1767ebd7493d)



## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
