### PR TITLE
Add `success` and `warning` Badge variants

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -23,6 +23,10 @@ type Story = StoryObj<typeof Badge>;
 
 export const Default: Story = { args: { variant: "default" } };
 export const Secondary: Story = { args: { variant: "secondary" } };
+export const Success: Story = { args: { variant: "success" } };
+export const SuccessLight: Story = { args: { variant: "successLight" } };
+export const Warning: Story = { args: { variant: "warning" } };
+export const WarningLight: Story = { args: { variant: "warningLight" } };
 export const Destructive: Story = { args: { variant: "destructive" } };
 export const DestructiveLight: Story = {
   args: { variant: "destructiveLight" },

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -22,7 +22,7 @@ export const badgeVariance = cva(
        * - `secondary`: filled with secondary color.
        * - `success`: filled with success color.
        *    Should be used for indicating positive and successful statues.
-       * - `successLight`: filled with destructive color of reduced opacity.
+       * - `successLight`: filled with success color of reduced opacity.
        *    Should be used for indicating positive and successful statues.
        * - `warning`: filled with warning color.
        *    Should be used for bringing users' attention to potential upcoming problems or semi-success statuses.

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -46,7 +46,7 @@ export const badgeVariance = cva(
         successLight: "border-transparent bg-success/10 text-success",
         warning:
           "border-transparent bg-warning text-warning-foreground shadow-sm hover:bg-warning/80",
-        warningLight: "border-transparent bg-warning/10 text-warning",
+        warningLight: "border-transparent bg-warning/10 text-warning-dark",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/80",
         destructiveLight:

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -20,6 +20,14 @@ export const badgeVariance = cva(
        * Controls the visual variant of the badge.
        * - `default`: filled with primary color.
        * - `secondary`: filled with secondary color.
+       * - `success`: filled with success color.
+       *    Should be used for indicating positive and successful statues.
+       * - `successLight`: filled with destructive color of reduced opacity.
+       *    Should be used for indicating positive and successful statues.
+       * - `warning`: filled with warning color.
+       *    Should be used for bringing users' attention to potential upcoming problems or semi-success statuses.
+       * - `warningLight`: filled with warning color of reduced opacity.
+       *    Should be used for bringing users' attention to potential upcoming problems or semi-negative statuses.
        * - `destructive`: filled with destructive color.
        *    Should be used for indicating negative and unsuccessful statues.
        * - `destructiveLight`: filled with destructive color of reduced opacity.
@@ -33,6 +41,12 @@ export const badgeVariance = cva(
           "border-transparent bg-primary text-primary-foreground shadow-sm hover:bg-primary/80",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        success:
+          "border-transparent bg-success text-success-foreground shadow-sm hover:bg-success/80",
+        successLight: "border-transparent bg-success/10 text-success",
+        warning:
+          "border-transparent bg-warning text-warning-foreground shadow-sm hover:bg-warning/80",
+        warningLight: "border-transparent bg-warning/10 text-warning",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/80",
         destructiveLight:

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -32,6 +32,7 @@ SPDX-License-Identifier: MIT
   --color-success: var(--color-success);
   --color-success-foreground: var(--color-success-foreground);
   --color-warning: var(--color-warning);
+  --color-warning-dark: var(--color-warning-dark);
   --color-warning-foreground: var(--color-warning-foreground);
   --color-destructive: var(--color-destructive);
   --color-destructive-foreground: var(--color-destructive-foreground);

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -29,6 +29,10 @@ SPDX-License-Identifier: MIT
   --color-accent-foreground: var(--color-accent-foreground);
   --color-border: var(--color-border);
   --color-input: var(--color-input);
+  --color-success: var(--color-success);
+  --color-success-foreground: var(--color-success-foreground);
+  --color-warning: var(--color-warning);
+  --color-warning-foreground: var(--color-warning-foreground);
   --color-destructive: var(--color-destructive);
   --color-destructive-foreground: var(--color-destructive-foreground);
   --color-ring: var(--color-ring);

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -33,7 +33,8 @@ export const lightTheme: Theme = {
   "color-destructive-foreground": "rgb(243 243 243)",
   "color-success": "rgb(34 197 94)",
   "color-success-foreground": "rgb(243 243 243)",
-  "color-warning": "rgb(234 179 8)",
-  "color-warning-foreground": "rgb(243 243 243)",
+  "color-warning": "rgb(252 211 3)",
+  "color-warning-dark": "rgb(153 101 21)",
+  "color-warning-foreground": "rgb(9 4 4)",
   "color-ring": "rgb(62 176 85)",
 };

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -31,5 +31,9 @@ export const lightTheme: Theme = {
   "color-input": "rgb(232 215 221)",
   "color-destructive": "rgb(222 65 38)",
   "color-destructive-foreground": "rgb(243 243 243)",
+  "color-success": "rgb(34 197 94)",
+  "color-success-foreground": "rgb(243 243 243)",
+  "color-warning": "rgb(234 179 8)",
+  "color-warning-foreground": "rgb(243 243 243)",
   "color-ring": "rgb(62 176 85)",
 };

--- a/src/theme/utils.ts
+++ b/src/theme/utils.ts
@@ -39,6 +39,7 @@ export interface Theme {
   "color-success": RGBColor;
   "color-success-foreground": RGBColor;
   "color-warning": RGBColor;
+  "color-warning-dark": RGBColor;
   "color-warning-foreground": RGBColor;
   "color-ring": RGBColor;
 }

--- a/src/theme/utils.ts
+++ b/src/theme/utils.ts
@@ -36,5 +36,9 @@ export interface Theme {
   "color-input": RGBColor;
   "color-destructive": RGBColor;
   "color-destructive-foreground": RGBColor;
+  "color-success": RGBColor;
+  "color-success-foreground": RGBColor;
+  "color-warning": RGBColor;
+  "color-warning-foreground": RGBColor;
   "color-ring": RGBColor;
 }


### PR DESCRIPTION
# Add `success` and `warning` Badge variants

## :recycle: Current situation & Problem
Primary role of a Badge is to represent statuses. We need to cover common scenarios like `warning` or `success` status. 


## :gear: Release Notes
* Add success and destructive colors to the theme
* Add success and warning Badge variant


## :white_check_mark: Testing
Tested visually through Storybook.

<img width="705" alt="image" src="https://github.com/user-attachments/assets/c5fc1837-4e4d-4145-8e1b-31dc06c57d9a" />




## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
