### PR TITLE
Expand AsideBrandLayout composability

### DIFF
--- a/src/molecules/AsideBrandLayout/AsideBrandLayout.stories.tsx
+++ b/src/molecules/AsideBrandLayout/AsideBrandLayout.stories.tsx
@@ -7,11 +7,15 @@
 //
 
 import { type Meta, type StoryObj } from "@storybook/react";
-import { AsideBrandLayout } from "./AsideBrandLayout";
+import {
+  AsideBrandLayoutRoot,
+  AsideBrandLayoutAside,
+  AsideBrandLayoutMain,
+} from "./AsideBrandLayout";
 
-const meta: Meta<typeof AsideBrandLayout> = {
+const meta: Meta<typeof AsideBrandLayoutRoot> = {
   title: "Molecules/AsideBrandLayout",
-  component: AsideBrandLayout,
+  component: AsideBrandLayoutRoot,
   parameters: {
     layout: "fullscreen",
   },
@@ -19,8 +23,83 @@ const meta: Meta<typeof AsideBrandLayout> = {
 
 export default meta;
 
-type Story = StoryObj<typeof AsideBrandLayout>;
+type Story = StoryObj<typeof AsideBrandLayoutRoot>;
 
-export const Default: Story = {
-  args: { aside: "Aside content", children: "Main content" },
+const MockSignInForm = () => (
+  <div className="w-full max-w-md space-y-6 p-2">
+    <h2 className="text-3xl font-bold">Sign In</h2>
+    <p className="text-muted-foreground">Sign in to your account to continue</p>
+    <div className="space-y-4">
+      <div className="bg-muted h-10 w-full rounded-md" />
+      <div className="bg-muted h-10 w-full rounded-md" />
+      <div className="bg-primary h-10 w-full rounded-md" />
+    </div>
+  </div>
+);
+
+/**
+ * Basic structure of the aside brand layout.
+ */
+export const Simple: Story = {
+  render: () => (
+    <AsideBrandLayoutRoot>
+      <AsideBrandLayoutAside>Aside content</AsideBrandLayoutAside>
+      <AsideBrandLayoutMain>Main content</AsideBrandLayoutMain>
+    </AsideBrandLayoutRoot>
+  ),
+};
+
+/**
+ * Branded layout example with Stanford logo and your application name.
+ */
+export const Branded: Story = {
+  render: () => (
+    <AsideBrandLayoutRoot>
+      <AsideBrandLayoutAside>
+        <h1 className="text-2xl font-bold">Spezi Web Design System</h1>
+        <img
+          src="https://biodesign.stanford.edu/_jcr_content/local-header/_jcr_content/custom-logo.img.full.high.png"
+          alt="Stanford Byers Center for Biodesign Logo"
+          className="w-40"
+        />
+      </AsideBrandLayoutAside>
+      <AsideBrandLayoutMain>
+        <MockSignInForm />
+      </AsideBrandLayoutMain>
+    </AsideBrandLayoutRoot>
+  ),
+};
+
+/**
+ * Gradient-filled aside.
+ */
+export const GradientAside: Story = {
+  render: () => (
+    <AsideBrandLayoutRoot>
+      <AsideBrandLayoutAside className="bg-gradient-to-br from-purple-800 via-violet-900 to-blue-900" />
+      <AsideBrandLayoutMain>
+        <MockSignInForm />
+      </AsideBrandLayoutMain>
+    </AsideBrandLayoutRoot>
+  ),
+};
+
+/**
+ * Image-filled aside.
+ */
+export const ImageAside: Story = {
+  render: () => (
+    <AsideBrandLayoutRoot>
+      <AsideBrandLayoutAside
+        className="bg-cover"
+        style={{
+          backgroundImage:
+            "url(https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?fm=jpg&q=60&w=3000)",
+        }}
+      />
+      <AsideBrandLayoutMain>
+        <MockSignInForm />
+      </AsideBrandLayoutMain>
+    </AsideBrandLayoutRoot>
+  ),
 };

--- a/src/molecules/AsideBrandLayout/AsideBrandLayout.test.tsx
+++ b/src/molecules/AsideBrandLayout/AsideBrandLayout.test.tsx
@@ -7,11 +7,20 @@
 //
 
 import { render, screen } from "@testing-library/react";
-import { AsideBrandLayout } from ".";
+import {
+  AsideBrandLayoutRoot,
+  AsideBrandLayoutAside,
+  AsideBrandLayoutMain,
+} from ".";
 
 describe("AsideBrandLayout", () => {
-  it("renders aside and children elements", () => {
-    render(<AsideBrandLayout aside="Aside">Main</AsideBrandLayout>);
+  it("renders aside and main elements", () => {
+    render(
+      <AsideBrandLayoutRoot>
+        <AsideBrandLayoutAside>Aside</AsideBrandLayoutAside>
+        <AsideBrandLayoutMain>Main</AsideBrandLayoutMain>
+      </AsideBrandLayoutRoot>,
+    );
 
     const aside = screen.getByText("Aside");
     expect(aside).toBeInTheDocument();

--- a/src/molecules/AsideBrandLayout/AsideBrandLayout.tsx
+++ b/src/molecules/AsideBrandLayout/AsideBrandLayout.tsx
@@ -6,12 +6,10 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { type ComponentProps, type ReactNode } from "react";
+import { type ComponentProps } from "react";
 import { cn } from "@/utils/className";
 
-export interface AsideBrandLayoutProps extends ComponentProps<"div"> {
-  aside?: ReactNode;
-}
+export interface AsideBrandLayoutRootProps extends ComponentProps<"div"> {}
 
 /**
  * A layout component that provides a branded aside section and main content area.
@@ -19,18 +17,38 @@ export interface AsideBrandLayoutProps extends ComponentProps<"div"> {
  *
  * The aside section is only visible on large screens (lg breakpoint and above).
  *
+ * @example
+ * <AsideBrandLayoutRoot>
+ *   <AsideBrandLayoutAside>
+ *     <BrandLogo />
+ *   </AsideBrandLayoutAside>
+ *   <AsideBrandLayoutMain>
+ *     <SignInForm />
+ *   </AsideBrandLayoutMain>
+ * </AsideBrandLayoutRoot>
  *
  * @example
- * <AsideBrandLayout aside={<BrandLogo />}>
- *   <LoginForm />
- * </AsideBrandLayout>
+ * // Stanford Branded example
+ * <AsideBrandLayoutRoot>
+ *   <AsideBrandLayoutAside>
+ *     <h1 className="text-2xl font-bold">Spezi Web Design System</h1>
+ *     <img
+ *       src="https://biodesign.stanford.edu/_jcr_content/local-header/_jcr_content/custom-logo.img.full.high.png"
+ *       alt="Stanford Byers Center for Biodesign Logo"
+ *       className="w-40"
+ *     />
+ *   </AsideBrandLayoutAside>
+ *   <AsideBrandLayoutMain>
+ *     <SignInForm />
+ *   </AsideBrandLayoutMain>
+ * </AsideBrandLayoutRoot>
+ *
  */
-export const AsideBrandLayout = ({
-  aside,
+export const AsideBrandLayoutRoot = ({
   children,
   className,
   ...props
-}: AsideBrandLayoutProps) => (
+}: AsideBrandLayoutRootProps) => (
   <div
     className={cn(
       "w-full lg:grid lg:min-h-screen lg:grid-cols-[450px_1fr] xl:grid-cols-[600px_1fr]",
@@ -38,11 +56,63 @@ export const AsideBrandLayout = ({
     )}
     {...props}
   >
-    <aside className="bg-accent hidden flex-col items-center justify-between gap-20 py-40 lg:flex">
-      {aside}
-    </aside>
-    <main className="flex min-h-screen items-center justify-center py-12">
-      {children}
-    </main>
+    {children}
   </div>
+);
+
+export interface AsideBrandLayoutAsideProps extends ComponentProps<"aside"> {}
+
+/**
+ * The aside section of the AsideBrandLayout.
+ * This component is only visible on large screens (lg breakpoint and above).
+ * It provides a branded section with a light background color and centered content.
+ *
+ * @example
+ * <AsideBrandLayoutAside>
+ *   <BrandLogo />
+ *   <BrandDescription />
+ * </AsideBrandLayoutAside>
+ */
+export const AsideBrandLayoutAside = ({
+  children,
+  className,
+  ...props
+}: AsideBrandLayoutAsideProps) => (
+  <aside
+    className={cn(
+      "bg-accent hidden flex-col items-center justify-between gap-20 py-40 lg:flex",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </aside>
+);
+
+export interface AsideBrandLayoutMainProps extends ComponentProps<"main"> {}
+
+/**
+ * The main content area of the AsideBrandLayout.
+ * This component provides a centered container for the primary content,
+ * such as forms, content sections, or other interactive elements.
+ *
+ * @example
+ * <AsideBrandLayoutMain>
+ *   <LoginForm />
+ * </AsideBrandLayoutMain>
+ */
+export const AsideBrandLayoutMain = ({
+  children,
+  className,
+  ...props
+}: AsideBrandLayoutMainProps) => (
+  <main
+    className={cn(
+      "flex min-h-screen items-center justify-center py-12",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </main>
 );


### PR DESCRIPTION
# Expand AsideBrandLayout composability

## :recycle: Current situation & Problem
`AsideBrandLayout` was introduced, but it wasn't composable enough. By splitting it into separate components, API is open to slight modifications like changing background or adding styles. New examples also provide default use case and show the composability pros.


## :gear: Release Notes
* Expand `AsideBrandLayout` composability
* Provide better `AsideBrandLayout` examples


## :white_check_mark: Testing
https://github.com/user-attachments/assets/db0dd0b4-9f94-4cc0-942c-eb7c61c1d714




## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
