### PR TITLE
Add `CheckboxGroup` component

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/components/Checkbox.d.ts",
       "default": "./dist/components/Checkbox.js"
     },
+    "./components/CheckboxGroup": {
+      "types": "./dist/components/CheckboxGroup.d.ts",
+      "default": "./dist/components/CheckboxGroup.js"
+    },
     "./components/Card": {
       "types": "./dist/components/Card.d.ts",
       "default": "./dist/components/Card.js"

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -15,6 +15,8 @@ type CheckboxProps = ComponentProps<typeof CheckboxPrimitive.Root>;
 /**
  * Checkbox component, it implements just the Checkbox control input.
  *
+ * Use [CheckboxGroup](src/components/CheckboxGroup) for a complete checkbox selection list component.
+ *
  * @example
  * // It's typically used with a SideLabel for proper labeling
  * <SideLabel label="Show unread only">

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -1,0 +1,131 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { action } from "@storybook/addon-actions";
+import { useArgs } from "@storybook/core/preview-api";
+import { type Meta, type StoryObj } from "@storybook/react";
+import { CheckboxGroup } from "./CheckboxGroup";
+
+const meta: Meta<typeof CheckboxGroup> = {
+  title: "Components/CheckboxGroup",
+  component: CheckboxGroup,
+  args: {
+    options: [
+      { label: "Travel", value: "travel" },
+      { label: "Music", value: "music" },
+      { label: "Cars", value: "cars" },
+      { label: "Food", value: "food" },
+      { label: "Technology", value: "tech" },
+    ],
+    onChange: action("onChange"),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CheckboxGroup>;
+
+export const Default: Story = {
+  render: function Render(args) {
+    const [, updateArgs] = useArgs();
+    return (
+      <CheckboxGroup
+        {...args}
+        onChange={(values) => {
+          updateArgs({ value: values });
+          action("onChange")(values);
+        }}
+      />
+    );
+  },
+  args: {
+    value: ["food", "cars"],
+  },
+};
+
+export const WithDefaultValue: Story = {
+  args: {
+    defaultValue: ["travel", "technology"],
+  },
+};
+
+export const WithCustomLabels: Story = {
+  args: {
+    options: [
+      {
+        label: (
+          <div className="flex flex-col">
+            <span className="font-medium">Travel</span>
+            <span className="text-xs text-gray-500">
+              Exploring new destinations
+            </span>
+          </div>
+        ),
+        value: "travel",
+      },
+      {
+        label: (
+          <div className="flex flex-col">
+            <span className="font-medium">Technology</span>
+            <span className="text-xs text-gray-500">
+              Gadgets and innovations
+            </span>
+          </div>
+        ),
+        value: "technology",
+      },
+      {
+        label: (
+          <div className="flex flex-col">
+            <span className="font-medium">Cars</span>
+            <span className="text-xs text-gray-500">
+              Performance and mechanics
+            </span>
+          </div>
+        ),
+        value: "cars",
+      },
+    ],
+    defaultValue: ["cars"],
+  },
+};
+
+export const Horizontal: Story = {
+  args: {
+    direction: "row",
+  },
+};
+
+export const HorizontalWrapped: Story = {
+  args: {
+    direction: "row",
+    className: "max-w-40",
+  },
+};
+
+export const WithNumericValues: Story = {
+  args: {
+    options: [
+      { label: "One", value: 1 },
+      { label: "Two", value: 2 },
+      { label: "Three", value: 3 },
+    ],
+    defaultValue: [1, 3],
+  },
+};
+
+export const WithDisabledOptions: Story = {
+  args: {
+    options: [
+      { label: "Available", value: "available" },
+      { label: "Unavailable", value: "unavailable", disabled: true },
+      { label: "Available Too", value: "available-too" },
+    ],
+    defaultValue: ["available"],
+  },
+};

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -1,0 +1,162 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vitest } from "vitest";
+import { CheckboxGroup } from "./CheckboxGroup";
+
+describe("CheckboxGroup component", () => {
+  const options = [
+    { label: "Option 1", value: "option1" },
+    { label: "Option 2", value: "option2" },
+    { label: "Option 3", value: "option3" },
+  ];
+
+  it("renders all options with labels", () => {
+    render(<CheckboxGroup options={options} />);
+
+    expect(screen.getByText("Option 1")).toBeInTheDocument();
+    expect(screen.getByText("Option 2")).toBeInTheDocument();
+    expect(screen.getByText("Option 3")).toBeInTheDocument();
+    expect(screen.getAllByRole("checkbox")).toHaveLength(3);
+  });
+
+  it("respects the defaultValue prop", () => {
+    render(<CheckboxGroup options={options} defaultValue={["option2"]} />);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[0]).not.toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+    expect(checkboxes[2]).not.toBeChecked();
+  });
+
+  it("respects multiple defaultValues", () => {
+    render(
+      <CheckboxGroup options={options} defaultValue={["option1", "option3"]} />,
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+    expect(checkboxes[2]).toBeChecked();
+  });
+
+  it("respects the value prop (controlled component)", () => {
+    render(<CheckboxGroup options={options} value={["option3"]} />);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[0]).not.toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+    expect(checkboxes[2]).toBeChecked();
+  });
+
+  it("calls onChange when a checkbox is selected", () => {
+    const handleChange = vitest.fn();
+
+    render(<CheckboxGroup options={options} onChange={handleChange} />);
+
+    const secondCheckbox = screen.getAllByRole("checkbox")[1];
+    fireEvent.click(secondCheckbox);
+
+    expect(handleChange).toHaveBeenCalledWith(["option2"]);
+  });
+
+  it("allows selecting multiple options", () => {
+    const handleChange = vitest.fn();
+
+    render(<CheckboxGroup options={options} onChange={handleChange} />);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[0]);
+    expect(handleChange).toHaveBeenCalledWith(["option1"]);
+
+    // Reset mock to check next call clearly
+    handleChange.mockReset();
+
+    // Now select second checkbox while first is already selected
+    fireEvent.click(checkboxes[1]);
+    expect(handleChange).toHaveBeenCalledWith(["option1", "option2"]);
+  });
+
+  it("allows deselecting options", () => {
+    const handleChange = vitest.fn();
+
+    render(
+      <CheckboxGroup
+        options={options}
+        defaultValue={["option1", "option2"]}
+        onChange={handleChange}
+      />,
+    );
+
+    const firstCheckbox = screen.getAllByRole("checkbox")[0];
+    fireEvent.click(firstCheckbox);
+
+    expect(handleChange).toHaveBeenCalledWith(["option2"]);
+  });
+
+  it("accepts numeric values", () => {
+    const numericOptions = [
+      { label: "Option 1", value: 1 },
+      { label: "Option 2", value: 2 },
+    ];
+
+    const handleChange = vitest.fn();
+
+    render(
+      <CheckboxGroup
+        options={numericOptions}
+        value={[1]}
+        onChange={handleChange}
+      />,
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[0]).toBeChecked();
+
+    fireEvent.click(checkboxes[1]);
+    expect(handleChange).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it("applies custom className to the root element", () => {
+    render(<CheckboxGroup options={options} className="test-class" />);
+
+    const root = screen
+      .getAllByRole("checkbox")[0]
+      .closest("div[role='group']");
+    expect(root).toHaveClass("test-class");
+  });
+
+  it("works with ReactNode labels", () => {
+    const optionsWithReactNodes = [
+      {
+        label: <div data-testid="custom-label">Custom Label</div>,
+        value: "custom",
+      },
+      { label: "Regular Label", value: "regular" },
+    ];
+
+    render(<CheckboxGroup options={optionsWithReactNodes} />);
+
+    expect(screen.getByTestId("custom-label")).toBeInTheDocument();
+    expect(screen.getByText("Regular Label")).toBeInTheDocument();
+  });
+
+  it("respects disabled options", () => {
+    const optionsWithDisabled = [
+      { label: "Enabled", value: "enabled" },
+      { label: "Disabled", value: "disabled", disabled: true },
+    ];
+
+    render(<CheckboxGroup options={optionsWithDisabled} />);
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[0]).not.toBeDisabled();
+    expect(checkboxes[1]).toBeDisabled();
+  });
+});

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -1,0 +1,123 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { type ComponentProps, type ReactNode } from "react";
+import { Checkbox } from "@/components/Checkbox";
+import { SideLabel } from "@/components/SideLabel";
+import { cn } from "@/utils/className";
+
+export interface CheckboxOption<T extends string | number = string> {
+  /**
+   * Label to display next to the checkbox.
+   * Can be a string or a ReactNode for more complex labels.
+   */
+  label: ReactNode;
+  /**
+   * Value associated with this checkbox option.
+   */
+  value: T;
+  /**
+   * Whether this option is disabled.
+   */
+  disabled?: boolean;
+}
+
+export interface CheckboxGroupProps<T extends string | number = string>
+  extends Omit<ComponentProps<"div">, "defaultValue" | "onChange"> {
+  /**
+   * Options to render as checkboxes.
+   */
+  options: Array<CheckboxOption<T>>;
+  /**
+   * Currently selected values.
+   */
+  value?: T[];
+  /**
+   * Callback fired when the values change.
+   */
+  onChange?: (values: T[]) => void;
+  /**
+   * Default values to be selected initially for uncontrolled usage.
+   */
+  defaultValue?: T[];
+  /**
+   * Direction of the checkbox group.
+   *
+   * - `row`: Arranges checkbox horizontally in a row with wrapping if necessary
+   * - `column`: Arranges checkbox vertically in a column
+   *
+   * @default "column"
+   */
+  direction?: "row" | "column";
+}
+
+/**
+ * A group of checkboxes for selecting multiple options.
+ *
+ * @template T The type of the value (string or number, supports enum)
+ *
+ * @example
+ * <CheckboxGroup
+ *   options={[
+ *     { label: "Option 1", value: "option1" },
+ *     { label: "Option 2", value: "option2" },
+ *     { label: "Option 3", value: "option3" },
+ *   ]}
+ *   defaultValue={["option1"]}
+ *   onChange={(values) => console.log(values)}
+ * />
+ */
+export const CheckboxGroup = <T extends string | number>({
+  options,
+  value: valueProp,
+  onChange,
+  defaultValue = [],
+  className,
+  direction = "column",
+  ...props
+}: CheckboxGroupProps<T>) => {
+  const [value, setValue] = useControllableState({
+    prop: valueProp,
+    defaultProp: defaultValue,
+    onChange,
+    caller: "CheckboxGroup",
+  });
+
+  const handleChange = (optionValue: T, isChecked: boolean) => {
+    const newValue =
+      isChecked ?
+        [...value, optionValue]
+      : value.filter((selectedValue) => selectedValue !== optionValue);
+    setValue(newValue);
+  };
+
+  return (
+    <div
+      role="group"
+      className={cn(
+        "flex gap-x-4 gap-y-2",
+        direction === "column" ? "flex-col" : "flex-wrap",
+        className,
+      )}
+      {...props}
+    >
+      {options.map((option) => (
+        <SideLabel key={option.value} label={option.label}>
+          <Checkbox
+            checked={value.includes(option.value)}
+            disabled={option.disabled}
+            onCheckedChange={(isChecked) =>
+              handleChange(option.value, !!isChecked)
+            }
+          />
+        </SideLabel>
+      ))}
+    </div>
+  );
+};

--- a/src/components/CheckboxGroup/index.tsx
+++ b/src/components/CheckboxGroup/index.tsx
@@ -1,0 +1,9 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+export * from "./CheckboxGroup";

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export * from "./components/SideLabel";
 export * from "./components/Switch";
 export * from "./components/Radio";
 export * from "./components/Checkbox";
+export * from "./components/CheckboxGroup";
 export * from "./components/Table";
 export * from "./components/Tabs";
 export * from "./components/Textarea";


### PR DESCRIPTION
# Add `CheckboxGroup` component

## :recycle: Current situation & Problem
As analogy to https://github.com/StanfordSpezi/spezi-web-design-system/pull/71, we need similar component for `Checkbox`. 


## :gear: Release Notes
* Add `CheckboxGroup` component


## :white_check_mark: Testing
![image](https://github.com/user-attachments/assets/4cf20a8e-1427-4363-b76d-9f6b5d3e7f3b)



## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
