### PR TITLE
Add `Collapsible` and `Accordion` components

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,10 @@
       "types": "./dist/components/Badge.d.ts",
       "default": "./dist/components/Badge.js"
     },
+    "./components/Collapsible": {
+      "types": "./dist/components/Collapsible.d.ts",
+      "default": "./dist/components/Collapsible.js"
+    },
     "./components/StateContainer": {
       "types": "./dist/components/StateContainer.d.ts",
       "default": "./dist/components/StateContainer.js"

--- a/package.json
+++ b/package.json
@@ -169,6 +169,10 @@
       "types": "./dist/components/Spinner.d.ts",
       "default": "./dist/components/Spinner.js"
     },
+    "./components/Accordion": {
+      "types": "./dist/components/Accordion.d.ts",
+      "default": "./dist/components/Accordion.js"
+    },
     "./components/Async": {
       "types": "./dist/components/Async.d.ts",
       "default": "./dist/components/Async.js"

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,0 +1,62 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  AccordionRoot,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "./Accordion";
+
+const meta: Meta<typeof AccordionRoot> = {
+  title: "Components/Accordion",
+  component: AccordionRoot,
+};
+
+export default meta;
+type Story = StoryObj<typeof AccordionRoot>;
+
+const InnerContent = () => (
+  <>
+    <AccordionItem value="item-1">
+      <AccordionTrigger>Accessibility</AccordionTrigger>
+      <AccordionContent>
+        It adheres to the WAI-ARIA design pattern.
+      </AccordionContent>
+    </AccordionItem>
+    <AccordionItem value="item-2">
+      <AccordionTrigger>Styles</AccordionTrigger>
+      <AccordionContent>It comes with default styling.</AccordionContent>
+    </AccordionItem>
+    <AccordionItem value="item-3">
+      <AccordionTrigger>Animation</AccordionTrigger>
+      <AccordionContent>It comes with a performant animation.</AccordionContent>
+    </AccordionItem>
+    <AccordionItem value="item-4">
+      <AccordionTrigger>Interactivity</AccordionTrigger>
+      <AccordionContent>It's activatable by keyboard</AccordionContent>
+    </AccordionItem>
+  </>
+);
+
+export const Default: Story = {
+  render: () => (
+    <AccordionRoot type="single" collapsible>
+      <InnerContent />
+    </AccordionRoot>
+  ),
+};
+
+export const Multiple: Story = {
+  render: () => (
+    <AccordionRoot type="multiple">
+      <InnerContent />
+    </AccordionRoot>
+  ),
+};

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -1,0 +1,111 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  AccordionRoot,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "./Accordion";
+
+describe("Accordion", () => {
+  it("renders accordion content correctly", () => {
+    render(
+      <AccordionRoot type="single">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Section 1</AccordionTrigger>
+          <AccordionContent>Content 1</AccordionContent>
+        </AccordionItem>
+      </AccordionRoot>,
+    );
+
+    expect(screen.getByText("Section 1")).toBeInTheDocument();
+    expect(screen.getByText("Content 1")).toBeInTheDocument();
+  });
+
+  it("toggles content visibility when trigger is clicked", () => {
+    render(
+      <AccordionRoot type="single" collapsible>
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Section 1</AccordionTrigger>
+          <AccordionContent>Content 1</AccordionContent>
+        </AccordionItem>
+      </AccordionRoot>,
+    );
+
+    const trigger = screen.getByText("Section 1");
+
+    // Content should be hidden by default
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+    // Click trigger to show content
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    // Click trigger again to hide content
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("supports multiple items with type 'single'", () => {
+    render(
+      <AccordionRoot type="single">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Section 1</AccordionTrigger>
+          <AccordionContent>Content 1</AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-2">
+          <AccordionTrigger>Section 2</AccordionTrigger>
+          <AccordionContent>Content 2</AccordionContent>
+        </AccordionItem>
+      </AccordionRoot>,
+    );
+
+    const trigger1 = screen.getByText("Section 1");
+    const trigger2 = screen.getByText("Section 2");
+
+    // Open first section
+    fireEvent.click(trigger1);
+    expect(trigger1).toHaveAttribute("aria-expanded", "true");
+    expect(trigger2).toHaveAttribute("aria-expanded", "false");
+
+    // Open second section (should close first)
+    fireEvent.click(trigger2);
+    expect(trigger1).toHaveAttribute("aria-expanded", "false");
+    expect(trigger2).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("supports multiple items with type 'multiple'", () => {
+    render(
+      <AccordionRoot type="multiple">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Section 1</AccordionTrigger>
+          <AccordionContent>Content 1</AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="item-2">
+          <AccordionTrigger>Section 2</AccordionTrigger>
+          <AccordionContent>Content 2</AccordionContent>
+        </AccordionItem>
+      </AccordionRoot>,
+    );
+
+    const trigger1 = screen.getByText("Section 1");
+    const trigger2 = screen.getByText("Section 2");
+
+    // Open first section
+    fireEvent.click(trigger1);
+    expect(trigger1).toHaveAttribute("aria-expanded", "true");
+    expect(trigger2).toHaveAttribute("aria-expanded", "false");
+
+    // Open second section (should keep first open)
+    fireEvent.click(trigger2);
+    expect(trigger1).toHaveAttribute("aria-expanded", "true");
+    expect(trigger2).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,0 +1,125 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { ChevronDownIcon } from "lucide-react";
+import { Accordion as AccordionPrimitive } from "radix-ui";
+import { type ComponentProps } from "react";
+import {
+  CollapsibleContentRoot,
+  CollapsibleContentInner,
+} from "@/components/Collapsible";
+import { cn } from "@/utils/className";
+
+/**
+ * An accordion is a vertically stacked set of interactive headings that each reveal a section of content.
+ *
+ * For unstyled variant just for one trigger, see `Collapsible`.
+ *
+ * @example
+ * // Just one item can be opened at once
+ * <AccordionRoot type="single" collapsible>
+ *   <AccordionItem value="item-1">
+ *     <AccordionTrigger>Accessibility</AccordionTrigger>
+ *     <AccordionContent>It adheres to the WAI-ARIA design pattern.</AccordionContent>
+ *   </AccordionItem>
+ *   <AccordionItem value="item-2">
+ *     <AccordionTrigger>Styles</AccordionTrigger>
+ *     <AccordionContent>It comes with default styling.</AccordionContent>
+ *   </AccordionItem>
+ * </Accordion>
+ *
+ * @example
+ * // Multiple items can be opened simultaneously
+ * <AccordionRoot type="multiple">
+ *   <AccordionItem value="item-1">...</AccordionItem>
+ *   <AccordionItem value="item-2">...</AccordionItem>
+ * </Accordion>
+ *
+ */
+export const AccordionRoot = (
+  props: ComponentProps<typeof AccordionPrimitive.Root>,
+) => <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+
+/**
+ * A single item within an accordion. Must be a direct child of `Accordion`.
+ * Each item needs a unique `value` prop to identify it.
+ *
+ * @example
+ * <AccordionItem value="item-1">
+ *   <AccordionTrigger>Trigger text</AccordionTrigger>
+ *   <AccordionContent>Content</AccordionContent>
+ * </AccordionItem>
+ */
+export const AccordionItem = ({
+  className,
+  ...props
+}: ComponentProps<typeof AccordionPrimitive.Item>) => (
+  <AccordionPrimitive.Item
+    data-slot="accordion-item"
+    className={cn("border-b last:border-b-0", className)}
+    {...props}
+  />
+);
+
+/**
+ * The trigger button that toggles the expanded state of an accordion item.
+ * Must be a direct child of `AccordionItem`.
+ *
+ * @example
+ * <AccordionTrigger>Section title</AccordionTrigger>
+ */
+export const AccordionTrigger = ({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof AccordionPrimitive.Trigger>) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      data-slot="accordion-trigger"
+      className={cn(
+        "interactive-opacity flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDownIcon className="text-muted-foreground size-4 shrink-0 translate-y-0.5 transition" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+);
+
+/**
+ * The expandable content section of an accordion item.
+ * Must be a direct child of `AccordionItem`.
+ *
+ * Features smooth animation through the CollapsiblePrimitive component.
+ *
+ * @example
+ * <AccordionContent>
+ *   Content that will be revealed when the accordion item is expanded.
+ * </AccordionContent>
+ */
+export const AccordionContent = ({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof AccordionPrimitive.Content>) => (
+  <AccordionPrimitive.Content
+    data-slot="accordion-content"
+    className="text-sm"
+    asChild
+    forceMount
+    {...props}
+  >
+    <CollapsibleContentRoot>
+      <CollapsibleContentInner>
+        <div className={cn("pt-0 pb-4", className)}>{children}</div>
+      </CollapsibleContentInner>
+    </CollapsibleContentRoot>
+  </AccordionPrimitive.Content>
+);

--- a/src/components/Accordion/index.ts
+++ b/src/components/Accordion/index.ts
@@ -1,0 +1,9 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+export * from "./Accordion";

--- a/src/components/Collapsible/Collapsible.stories.tsx
+++ b/src/components/Collapsible/Collapsible.stories.tsx
@@ -1,0 +1,55 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { type Meta, type StoryObj } from "@storybook/react";
+import {
+  CollapsibleRoot,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "./Collapsible";
+import { Button } from "../Button";
+
+const meta: Meta<typeof CollapsibleRoot> = {
+  title: "Components/Collapsible",
+  component: CollapsibleRoot,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CollapsibleRoot>;
+
+/**
+ * Use props to control the state of the component.
+ */
+export const Default: Story = {
+  render: () => (
+    <CollapsibleRoot>
+      <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+      <CollapsibleContent>Content to collapse</CollapsibleContent>
+    </CollapsibleRoot>
+  ),
+};
+
+/**
+ * Example usage with basic styling
+ */
+export const Styled: Story = {
+  render: () => (
+    <CollapsibleRoot defaultOpen={true} className="flex flex-col gap-4">
+      <CollapsibleTrigger asChild>
+        <Button>Trigger</Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="bg-accent rounded p-4">
+          <p>This content can be expanded and collapsed with the button.</p>
+          <p className="mt-2">The transition is smooth and performant.</p>
+        </div>
+      </CollapsibleContent>
+    </CollapsibleRoot>
+  ),
+};

--- a/src/components/Collapsible/Collapsible.test.tsx
+++ b/src/components/Collapsible/Collapsible.test.tsx
@@ -1,0 +1,46 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  CollapsibleRoot,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "./Collapsible";
+
+describe("Collapsible", () => {
+  it("renders collapsible content correctly", () => {
+    render(
+      <CollapsibleRoot>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent>Test Content</CollapsibleContent>
+      </CollapsibleRoot>,
+    );
+
+    expect(screen.getByText("Toggle")).toBeInTheDocument();
+    expect(screen.getByText("Test Content")).toBeInTheDocument();
+  });
+
+  it("toggles content visibility when trigger is clicked", () => {
+    render(
+      <CollapsibleRoot>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent>Test Content</CollapsibleContent>
+      </CollapsibleRoot>,
+    );
+
+    const trigger = screen.getByText("Toggle");
+    expect(trigger).toHaveAttribute("data-state", "closed");
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("data-state", "open");
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("data-state", "closed");
+  });
+});

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -1,0 +1,136 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { Slot, Collapsible as CollapsiblePrimitive } from "radix-ui";
+import type { ComponentProps } from "react";
+import { cn } from "@/utils/className";
+import { type AsChildProp } from "@/utils/misc";
+
+/**
+ * Primitive component for collapsible content. Root provides state.
+ *
+ * Renders fully accessible and animated collapsible, with no styles besides necessary.
+ *
+ * @example
+ * // Basic usage
+ * <CollapsibleRoot>
+ *   <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+ *   <CollapsibleContent>Content to collapse</CollapsibleContent>
+ * </CollapsibleRoot>
+ *
+ * @example
+ * // With button and content styles
+ * <CollapsibleRoot>
+ *   <CollapsibleTrigger asChild>
+ *     <Button>Trigger me</Button>
+ *   </CollapsibleTrigger>
+ *   <CollapsibleContent>
+ *     <div className="p-5 bg-primary">Content to collapse</div>
+ *   </CollapsibleContent>
+ * </CollapsibleRoot>
+ */
+export const CollapsibleRoot = CollapsiblePrimitive.Root;
+
+/**
+ * Button that toggles the collapsible.
+ *
+ * @example
+ * <CollapsibleTrigger asChild>
+ *   <Button>Trigger me</Button>
+ * </CollapsibleTrigger>
+ */
+export const CollapsibleTrigger = CollapsiblePrimitive.Trigger;
+
+export interface CollapsibleRootProps extends ComponentProps<"div"> {
+  asChild?: AsChildProp;
+}
+
+/**
+ * Primitive component providing collapsing animation.
+ * Mostly unstyled, provided just essential styles for collapsing.
+ *
+ * Collapse relies on animating `grid-template-rows`.
+ * `1fr` when visible, `0fr` when hidden.
+ * This approach guarantees performant transition and animation from 0 to max height.
+ *
+ * @example
+ * <CollapsibleContentRoot>
+ *   <CollapsibleContentInner>
+ *     Content to collapse
+ *   </CollapsibleContentInner>
+ * </CollapsibleContentRoot>
+ */
+export const CollapsibleContentRoot = ({
+  className,
+  asChild = false,
+  ...props
+}: CollapsibleRootProps) => {
+  const Comp = asChild ? Slot.Root : "div";
+  return (
+    <Comp
+      className={cn(
+        "grid !transition-all data-[state=closed]:grid-rows-[0fr] data-[state=open]:grid-rows-[1fr]",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+export interface CollapsibleContentProps extends ComponentProps<"div"> {
+  asChild?: AsChildProp;
+}
+
+/**
+ * Content container for CollapsibleContentRoot.
+ * It just renders div with hidden overflow, but this structure
+ * is necessary for collapsing to work.
+ *
+ * @remarks
+ * If you want to add padding or margin to the content,
+ * make sure to add it to the children of `CollapsibleContentInner`.
+ *
+ * @example
+ * <CollapsibleContentRoot>
+ *   <CollapsibleContentInner>
+ *     <div className="p-5">Content to collapse</div>
+ *   </CollapsibleContentInner>
+ * </CollapsibleContentRoot>
+ */
+export const CollapsibleContentInner = ({
+  className,
+  asChild = false,
+  ...props
+}: CollapsibleContentProps) => {
+  const Comp = asChild ? Slot.Root : "div";
+  return <Comp className={cn("overflow-hidden", className)} {...props} />;
+};
+
+/**
+ * Shows collapsed content. Has to be used within CollapsibleRoot.
+ *
+ * @example
+ * // Basic usage
+ * <CollapsibleContent>Content to collapse</CollapsibleContent>
+ *
+ * @example
+ * // With content styles
+ * <CollapsibleContent>
+ *   <div className="p-5 bg-primary">Content to collapse</div>
+ * </CollapsibleContent>
+ */
+export const CollapsibleContent = ({
+  children,
+  ...props
+}: ComponentProps<typeof CollapsiblePrimitive.Content>) => (
+  <CollapsiblePrimitive.Content asChild forceMount {...props}>
+    <CollapsibleContentRoot>
+      <CollapsibleContentInner>{children}</CollapsibleContentInner>
+    </CollapsibleContentRoot>
+  </CollapsiblePrimitive.Content>
+);

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -34,7 +34,9 @@ import { type AsChildProp } from "@/utils/misc";
  *   </CollapsibleContent>
  * </CollapsibleRoot>
  */
-export const CollapsibleRoot = CollapsiblePrimitive.Root;
+export const CollapsibleRoot = (props: ComponentProps<typeof CollapsiblePrimitive.Root>) => (
+  <CollapsiblePrimitive.Root data-slot="collapsible-root" {...props} />
+);
 
 /**
  * Button that toggles the collapsible.

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -34,9 +34,9 @@ import { type AsChildProp } from "@/utils/misc";
  *   </CollapsibleContent>
  * </CollapsibleRoot>
  */
-export const CollapsibleRoot = (props: ComponentProps<typeof CollapsiblePrimitive.Root>) => (
-  <CollapsiblePrimitive.Root data-slot="collapsible-root" {...props} />
-);
+export const CollapsibleRoot = (
+  props: ComponentProps<typeof CollapsiblePrimitive.Root>,
+) => <CollapsiblePrimitive.Root data-slot="collapsible-root" {...props} />;
 
 /**
  * Button that toggles the collapsible.

--- a/src/components/Collapsible/index.ts
+++ b/src/components/Collapsible/index.ts
@@ -1,0 +1,9 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+export * from "./Collapsible";

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export * from "./components/Spinner";
 export * from "./components/Async";
 export * from "./components/StateContainer";
 export * from "./components/Skeleton";
+export * from "./components/Accordion";
 export * from "./forms/useForm";
 export * from "./forms/Field";
 export * from "./forms/FormError";

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export * from "./components/Avatar";
 export * from "./components/Button";
 export * from "./components/Calendar";
 export * from "./components/Card";
+export * from "./components/Collapsible";
 export * from "./components/CopyText";
 export * from "./components/DataTable";
 export * from "./components/DatePicker";


### PR DESCRIPTION
# Add `Collapsible` and `Accordion` components

## :recycle: Current situation & Problem
It's hard to create accessible and performantly animated collapsible UI element. This PR provides:

* `Collapsible` as primitive component for rendering collapsibles
* `Accordion` as ready UI element to render list of items that can be accorded with 

## :gear: Release Notes
* Add `Collapsible` component
* Add `Accordion` component


## :white_check_mark: Testing

https://github.com/user-attachments/assets/2a0f0df7-d416-4a69-86d9-d0f4076a8fba


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
