### PR TITLE
Closes #82: Port formatValue utilities from Spezi Study Platform

### DIFF
--- a/src/utils/date/date.test.ts
+++ b/src/utils/date/date.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { formatDateRange, formatNilDateRange } from "./date";
+
+describe("formatDateRange", () => {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  it("formats a range with both start and end", () => {
+    const start = "2025-01-01";
+    const end = "2025-01-31";
+    const expected = formatter.formatRange(new Date(start), new Date(end));
+    expect(formatDateRange({ start, end }, formatter)).toBe(expected);
+  });
+
+  it("formats a range with only start", () => {
+    const start = "2025-01-01";
+    const expected = `from ${formatter.format(new Date(start))}`;
+    expect(formatDateRange({ start }, formatter)).toBe(expected);
+  });
+
+  it("formats a range with only end", () => {
+    const end = "2025-01-31";
+    const expected = `ending ${formatter.format(new Date(end))}`;
+    expect(formatDateRange({ end }, formatter)).toBe(expected);
+  });
+
+  it("returns null if no dates are provided", () => {
+    expect(formatDateRange({}, formatter)).toBeNull();
+  });
+
+  it("works with Date objects and numbers", () => {
+    const start = new Date(2025, 0, 1);
+    const end = new Date(2025, 0, 31);
+    const expected = formatter.formatRange(start, end);
+    expect(formatDateRange({ start, end }, formatter)).toBe(expected);
+
+    const startTimestamp = +start;
+    const endTimestamp = +end;
+    expect(
+      formatDateRange({ start: startTimestamp, end: endTimestamp }, formatter),
+    ).toBe(expected);
+  });
+});
+
+describe("formatNilDateRange", () => {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  it("returns null for null input", () => {
+    expect(formatNilDateRange(null, formatter)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(formatNilDateRange(undefined, formatter)).toBeNull();
+  });
+
+  it("returns null for empty object", () => {
+    expect(formatNilDateRange({}, formatter)).toBeNull();
+  });
+
+  it("delegates to formatDateRange for valid input", () => {
+    const start = "2025-01-01";
+    const end = "2025-01-31";
+    const expected = formatter.formatRange(new Date(start), new Date(end));
+    expect(formatNilDateRange({ start, end }, formatter)).toBe(expected);
+  });
+});

--- a/src/utils/date/date.test.ts
+++ b/src/utils/date/date.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import { formatDateRange, formatNilDateRange } from "./date";
 
 describe("formatDateRange", () => {

--- a/src/utils/date/date.ts
+++ b/src/utils/date/date.ts
@@ -11,6 +11,11 @@ import { type Nil } from "@/utils/misc";
 
 type DateInput = Date | string | number;
 
+interface DateRange {
+  start?: Nil<DateInput>;
+  end?: Nil<DateInput>;
+}
+
 /**
  * Formats date to include just the day, month and year.
  * The exact date format is based on locale.
@@ -56,3 +61,74 @@ export const formatDateTime = (value: DateInput) => {
  */
 export const formatNilDateTime = (value: Nil<DateInput>) =>
   value === "" || isNil(value) ? null : formatDateTime(value);
+
+/**
+ * Formats a date range into a human-readable string using locale-aware formatting.
+ *
+ * @example
+ * // Both dates provided
+ * formatDateRange({ start: "2025-01-01", end: "2025-01-31" })
+ * // Returns: "Jan 1 – 31, 2025"
+ *
+ * @example
+ * // Only start date
+ * formatDateRange({ start: "2025-01-01" })
+ * // Returns: "from Jan 1, 2025"
+ *
+ * @example
+ * // Only end date
+ * formatDateRange({ end: "2025-01-31" })
+ * // Returns: "ending Jan 31, 2025"
+ *
+ * @example
+ * // No dates provided
+ * formatDateRange({})
+ * // Returns: null
+ */
+export const formatDateRange = (
+  dateRange: DateRange,
+  formatter = new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }),
+) => {
+  if (dateRange.start && !dateRange.end) {
+    const formattedDate = formatter.format(new Date(dateRange.start));
+    return `from ${formattedDate}`;
+  }
+
+  if (dateRange.end && !dateRange.start) {
+    const formattedDate = formatter.format(new Date(dateRange.end));
+    return `ending ${formattedDate}`;
+  }
+
+  if (dateRange.start && dateRange.end) {
+    return formatter.formatRange(
+      new Date(dateRange.start),
+      new Date(dateRange.end),
+    );
+  }
+
+  return null;
+};
+
+/**
+ * Formats a date range like `formatDateRange`, but returns `null` for nil date ranges.
+ *
+ * @example
+ * formatNilDateRange({ start: "2025-01-01", end: "2025-01-31" })
+ * // Returns: "Jan 1 – 31, 2025"
+ *
+ * @example
+ * formatNilDateRange(null)
+ * // Returns: null
+ */
+export const formatNilDateRange = (
+  dateRange: Nil<DateRange>,
+  formatter = new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }),
+) => (isNil(dateRange) ? null : formatDateRange(dateRange, formatter));

--- a/src/utils/misc/misc.ts
+++ b/src/utils/misc/misc.ts
@@ -166,3 +166,27 @@ export const isEmpty: IsEmptyFunction = (value: unknown) => {
   if (valueIsObject) return Object.entries(value).length === 0;
   return false;
 };
+
+/**
+ * Formats a boolean value into a string representation.
+ * Returns "true" or "false" based on the boolean value.
+ *
+ * @example
+ * formatBoolean(true); // "true"
+ * formatBoolean(false); // "false"
+ */
+export const formatBoolean = (value: boolean) => {
+  return value ? "true" : "false";
+};
+
+/**
+ * Formats a boolean like `formatBoolean`, but returns `null` for nil values.
+ *
+ * @example
+ * formatNilBoolean(true); // "true"
+ * formatNilBoolean(false); // "false"
+ * formatNilBoolean(null); // null
+ * formatNilBoolean(undefined); // null
+ */
+export const formatNilBoolean = (value: Nil<boolean>) =>
+  isNil(value) ? null : formatBoolean(value);


### PR DESCRIPTION
# Port `formatValue` utilities from Spezi Study Platform

## :recycle: Current situation & Problem
In [Spezi Study Platform](https://github.com/StanfordSpezi/spezi-web-study-platform/pull/40/files#diff-553ddab2bacdbd3581907a788cc85a3736f1efbf45499be5d5cba153db16dd35), there are useful `formatDateRange` and `formatBoolean` utilities.


## :gear: Release Notes
### Date Range Formatting:

* Added `formatDateRange` function to format date ranges into human-readable strings, supporting scenarios with both start and end dates, only one date, or no dates.
* Added `formatNilDateRange` function to handle nil date ranges by delegating to `formatDateRange` or returning `null` for invalid input.
* Introduced `DateRange` interface to define the structure of date range inputs.

### Boolean Formatting:

* Added `formatBoolean` function to convert boolean values into their string representation ("true" or "false").
* Added `formatNilBoolean` function to handle nil boolean values, returning `null` for invalid input or delegating to `formatBoolean`.

## :white_check_mark: Testing
* Added comprehensive tests for `formatDateRange` and `formatNilDateRange` in `date.test.ts`.
* Added no tests for the `formatBoolean` and `formatNilBoolean` functions as they seemed robust enough.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).