### PR TITLE
Remove `any` from dev helpers

### DIFF
--- a/src/utils/dev/dev.ts
+++ b/src/utils/dev/dev.ts
@@ -5,7 +5,6 @@
 //
 // SPDX-License-Identifier: MIT
 //
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
  * Waits for provided milliseconds.
@@ -29,7 +28,7 @@ export const logPerformance = <T>(name: string, callback: () => T) => {
  * Throws a "not implemented" error.
  * Useful when implementing a feature partially in development environments.
  */
-export const notImplementedError: any = () => {
+export const notImplementedError = () => {
   throw new Error("Not implemented");
 };
 
@@ -37,6 +36,6 @@ export const notImplementedError: any = () => {
  * Shows a "not implemented" alert.
  * Useful when implementing a feature partially in development environments.
  */
-export const notImplementedAlert: any = () => {
+export const notImplementedAlert = () => {
   alert("Not implemented");
 };


### PR DESCRIPTION
# Remove `any` from dev helpers

## :recycle: Current situation & Problem
Initially `any` was placed there to simplify usage by allowing to use `notImplemented` and `notImplementedAlert` in place of `any` function. However, with our strict TypeScript linters, it results with errors. In order to actually make it simpler to use, it should be better to simplify satisfy the return type needs of a function that is mocked with `notImplemented` or `notImplementedAlert`. 

## :gear: Release Notes
* Remove `any` from dev helpers


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
