### PR TITLE
Add gap to DataTable header

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -227,7 +227,7 @@ export const DataTable = <Data,>({
       )}
     >
       {!minimal && (
-        <header className="flex items-center border-b p-4">
+        <header className="flex items-center gap-2 border-b p-4">
           <GlobalFilterInput
             onChange={(event) => setGlobalFilterDebounced(event.target.value)}
             entityName={entityName}


### PR DESCRIPTION
# Add gap to DataTable header

<img width="389" height="587" alt="image" src="https://github.com/user-attachments/assets/5374ea72-a0ef-4aad-b02e-398edc762410" />

## :recycle: Current situation & Problem
`DataTable` header can be extended with custom elements through `header` prop. In such scenarios, we need to make sure that there is at least minimal amount of gap to prevent clashing on smaller screens and guarantee standard visual safety. 


## :gear: Release Notes
* Add gap to DataTable header


## :white_check_mark: Testing
* Tested manually
* Storybooks for header already exist


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
