### PR TITLE
Replace specified transition classes with general purpose transition

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/utils/className";
 import { type AsChildProp } from "@/utils/misc";
 
 export const badgeVariance = cva(
-  "inline-flex-center border transition-colors focus-ring",
+  "inline-flex-center border transition focus-ring",
   {
     variants: {
       /**

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -65,7 +65,7 @@ export const buttonVariants = {
 };
 
 export const buttonVariance = cva(
-  "inline-flex items-center justify-center whitespace-nowrap transition-colors focus-ring disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap transition focus-ring disabled:pointer-events-none disabled:opacity-50",
   {
     variants: buttonVariants,
     defaultVariants: {

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -173,7 +173,7 @@ export const DropdownMenuItem = ({
 }) => (
   <DropdownMenuPrimitive.Item
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:size-4",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-hidden transition select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:size-4",
       inset && "pl-8",
       className,
     )}
@@ -203,7 +203,7 @@ export const DropdownMenuCheckboxItem = ({
 }: ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) => (
   <DropdownMenuPrimitive.CheckboxItem
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden transition select-none data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     checked={checked}
@@ -235,7 +235,7 @@ export const DropdownMenuRadioItem = ({
 }: ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) => (
   <DropdownMenuPrimitive.RadioItem
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden transition select-none data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     {...props}

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -74,7 +74,7 @@ export const TableRow = ({
 }: TableRowProps) => (
   <tr
     className={cn(
-      "data-[state=selected]:bg-muted border-b transition-colors",
+      "data-[state=selected]:bg-muted border-b transition",
       isHoverable && "hover:bg-muted/50",
       onClick &&
         "focus-visible:bg-primary/10 cursor-pointer focus-visible:outline-hidden",

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -63,7 +63,7 @@ SPDX-License-Identifier: MIT
 }
 
 @utility interactive-opacity {
-  @apply focus-ring transition-opacity hover:opacity-60;
+  @apply focus-ring transition hover:opacity-60;
 }
 
 @utility hide-all-hidden {


### PR DESCRIPTION
# Replace specified transition classes with general purpose transition

## :recycle: Current situation & Problem
`transition` is better for reusability than specific transition types like `transition-color`. If consumer wants to modify something inside the component, they're more free to do so.

## :gear: Release Notes
* Replace specified transition classes with general purpose transition


## :books: Documentation
* `transition-all` are kept as is, because those are more specific cases. 


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
