### PR TITLE
Add overlay prop to Avatar component

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -42,3 +42,11 @@ export const CustomFallback: Story = {
 
 export const SM: Story = { args: { size: "sm" } };
 export const LG: Story = { args: { size: "lg" } };
+
+export const WithOverlay: Story = {
+  args: {
+    overlay: (
+      <div className="absolute right-0 bottom-0 size-4 rounded-full border-2 border-white bg-green-500" />
+    ),
+  },
+};

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -47,4 +47,11 @@ describe("Avatar", () => {
     const element = screen.getByText("Lorem");
     expect(element).toBeInTheDocument();
   });
+
+  it("renders overlay content", () => {
+    render(<Avatar name="John Doe" overlay={<span>Badge</span>} />);
+
+    const overlay = screen.getByText("Badge");
+    expect(overlay).toBeInTheDocument();
+  });
 });

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -35,6 +35,12 @@ type AvatarProps = {
    * - Setting the alt text for the image
    */
   name?: Nil<string>;
+  /**
+   * Overlay content to render on top of the avatar.
+   * Can be any ReactNode - badges, status indicators, icons, etc.
+   * Positioned absolutely within the avatar container.
+   */
+  overlay?: ReactNode;
 } & VariantProps<typeof avatarVariance>;
 
 /**
@@ -68,15 +74,12 @@ export const avatarVariants = {
   },
 };
 
-export const avatarVariance = cva(
-  "relative flex shrink-0 overflow-hidden rounded-full",
-  {
-    variants: avatarVariants,
-    defaultVariants: {
-      size: "default",
-    },
+export const avatarVariance = cva("relative flex shrink-0", {
+  variants: avatarVariants,
+  defaultVariants: {
+    size: "default",
   },
-);
+});
 
 /**
  * Avatar component that displays a user's profile picture or fallback content.
@@ -92,6 +95,10 @@ export const avatarVariance = cva(
  * <Avatar name="John Doe" fallback={<UserIcon />} />
  *
  * @example
+ * // With overlay (e.g., status badge)
+ * <Avatar name="John Doe" overlay={<Badge variant="success" />} />
+ *
+ * @example
  * // Different sizes
  * <Avatar size="sm" name="John Doe" />
  * <Avatar size="default" name="John Doe" />
@@ -103,6 +110,7 @@ export const Avatar = ({
   fallback,
   size,
   name,
+  overlay,
 }: AvatarProps) => {
   const [isImageLoaded, setIsImageLoaded] = useState(false);
 
@@ -117,22 +125,25 @@ export const Avatar = ({
 
   return (
     <div className={cn(avatarVariance({ size }), className)}>
-      {src && (
-        <img
-          className={cn(
-            "aspect-square size-full object-cover",
-            !isImageLoaded && "opacity-0",
-          )}
-          src={src}
-          onLoad={() => setIsImageLoaded(true)}
-          alt={[name, "avatar"].filter(Boolean).join(" ")}
-        />
-      )}
-      {fallbackContent && (
-        <div className="flex-center bg-muted size-full rounded-full">
-          {fallbackContent}
-        </div>
-      )}
+      <div className="size-full overflow-hidden rounded-full">
+        {src && (
+          <img
+            className={cn(
+              "aspect-square size-full object-cover",
+              !isImageLoaded && "opacity-0",
+            )}
+            src={src}
+            onLoad={() => setIsImageLoaded(true)}
+            alt={[name, "avatar"].filter(Boolean).join(" ")}
+          />
+        )}
+        {fallbackContent && (
+          <div className="flex-center bg-muted size-full rounded-full">
+            {fallbackContent}
+          </div>
+        )}
+      </div>
+      {overlay && <div className="absolute inset-0">{overlay}</div>}
     </div>
   );
 };


### PR DESCRIPTION
# Add overlay prop to Avatar component

<img width="1103" height="967" alt="image" src="https://github.com/user-attachments/assets/513571b4-e67c-48d4-b8ad-8d9f9841120f" />

## :recycle: Current situation & Problem
Right now, there is no way to add children to the `<Avatar />` component. So if you wanted to add something like a `<Badge />` to the `<Avatar />`, you would need to add a wrapping `<div>` to do proper relative alignment.


## :gear: Release Notes
* Added a new `overlay` prop to the `Avatar` component, allowing users to render custom overlay content (e.g., badges or status indicators) positioned absolutely within the avatar container.
* Updated the `avatarVariance` styles to ensure proper positioning and overflow handling for the overlay. 

## :books: Documentation
* Added an example of using the `overlay` prop in the `Avatar` component's JSDoc comments, demonstrating how to include a status badge.
* Introduced a new story, `WithOverlay`, in the `Avatar.stories.tsx` file to showcase the overlay functionality in Storybook.

## :white_check_mark: Testing
Added a new test case to verify that the `Avatar` component correctly renders overlay content when the `overlay` prop is provided.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).