### PR TITLE
Add `useIsScrolled` hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,6 +264,10 @@
     "./utils/useMedia": {
       "types": "./dist/utils/useMedia.d.ts",
       "default": "./dist/utils/useMedia.js"
+    },
+    "./utils/useIsScrolled": {
+      "types": "./dist/utils/useIsScrolled.d.ts",
+      "default": "./dist/utils/useIsScrolled.js"
     }
   },
   "main": "dist/spezi-web-design-system.es.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * from "./utils/date";
 export * from "./utils/file";
 export * from "./utils/misc";
 export * from "./utils/tailwind";
+export * from "./utils/useIsScrolled";
 export * from "./utils/useOpenState";
 export * from "./utils/useMedia";
 export * from "./utils/navigator";

--- a/src/utils/useIsScrolled/index.ts
+++ b/src/utils/useIsScrolled/index.ts
@@ -1,0 +1,9 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+export * from "./useIsScrolled";

--- a/src/utils/useIsScrolled/useIsScrolled.test.ts
+++ b/src/utils/useIsScrolled/useIsScrolled.test.ts
@@ -26,7 +26,7 @@ describe("useIsScrolled", () => {
   };
 
   it("returns false initially when scroll position is 0", () => {
-    const { result } = renderHook(() => useIsScrolled());
+    const { result } = renderHook(() => useIsScrolled(0));
     expect(result.current).toBe(false);
   });
 
@@ -36,12 +36,12 @@ describe("useIsScrolled", () => {
       value: 100,
     });
 
-    const { result } = renderHook(() => useIsScrolled());
+    const { result } = renderHook(() => useIsScrolled(0));
     expect(result.current).toBe(true);
   });
 
   it("returns true when scrolled past default threshold (0)", () => {
-    const { result } = renderHook(() => useIsScrolled());
+    const { result } = renderHook(() => useIsScrolled(0));
 
     act(() => mockScrollEvent(1));
     expect(result.current).toBe(true);
@@ -92,7 +92,7 @@ describe("useIsScrolled", () => {
 
   it("cleans up event listener on unmount", () => {
     const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
-    const { unmount } = renderHook(() => useIsScrolled());
+    const { unmount } = renderHook(() => useIsScrolled(0));
 
     unmount();
 

--- a/src/utils/useIsScrolled/useIsScrolled.test.ts
+++ b/src/utils/useIsScrolled/useIsScrolled.test.ts
@@ -1,0 +1,104 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { act, renderHook } from "@testing-library/react";
+import { useIsScrolled } from "./useIsScrolled";
+
+describe("useIsScrolled", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "scrollY", {
+      writable: true,
+      value: 0,
+    });
+  });
+
+  const mockScrollEvent = (scrollY: number) => {
+    Object.defineProperty(window, "scrollY", {
+      writable: true,
+      value: scrollY,
+    });
+    window.dispatchEvent(new Event("scroll"));
+  };
+
+  it("returns false initially when scroll position is 0", () => {
+    const { result } = renderHook(() => useIsScrolled());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true initially when page is already scrolled on mount", () => {
+    Object.defineProperty(window, "scrollY", {
+      writable: true,
+      value: 100,
+    });
+
+    const { result } = renderHook(() => useIsScrolled());
+    expect(result.current).toBe(true);
+  });
+
+  it("returns true when scrolled past default threshold (0)", () => {
+    const { result } = renderHook(() => useIsScrolled());
+
+    act(() => mockScrollEvent(1));
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when scroll position equals threshold", () => {
+    const { result } = renderHook(() => useIsScrolled(100));
+
+    act(() => mockScrollEvent(100));
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when scrolled past custom threshold", () => {
+    const { result } = renderHook(() => useIsScrolled(100));
+
+    act(() => mockScrollEvent(101));
+    expect(result.current).toBe(true);
+  });
+
+  it("updates state when crossing threshold in both directions", () => {
+    const { result } = renderHook(() => useIsScrolled(50));
+
+    expect(result.current).toBe(false);
+
+    act(() => mockScrollEvent(100));
+    expect(result.current).toBe(true);
+
+    act(() => mockScrollEvent(25));
+    expect(result.current).toBe(false);
+  });
+
+  it("updates when threshold prop changes", () => {
+    let threshold = 50;
+    const { result, rerender } = renderHook(() => useIsScrolled(threshold));
+
+    act(() => mockScrollEvent(75));
+    expect(result.current).toBe(true);
+
+    threshold = 100;
+    rerender();
+    expect(result.current).toBe(false);
+  });
+
+  it("handles negative threshold values", () => {
+    const { result } = renderHook(() => useIsScrolled(-10));
+    expect(result.current).toBe(true);
+  });
+
+  it("cleans up event listener on unmount", () => {
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderHook(() => useIsScrolled());
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+    );
+  });
+});

--- a/src/utils/useIsScrolled/useIsScrolled.ts
+++ b/src/utils/useIsScrolled/useIsScrolled.ts
@@ -16,14 +16,14 @@ import { useEffect, useState } from "react";
  *
  * @example
  * ```tsx
- * // Basic usage - triggers on any scroll
- * const isScrolled = useIsScrolled();
- *
- * // Custom threshold - triggers after scrolling 100px
+ * // Triggers after scrolling 100px
  * const hasScrolledPastHeader = useIsScrolled(100);
+ *
+ * // Triggers on any scroll
+ * const isScrolled = useIsScrolled(0);
  * ```
  */
-export const useIsScrolled = (threshold = 0) => {
+export const useIsScrolled = (threshold: number) => {
   const [isScrolled, setIsScrolled] = useState(false);
 
   useEffect(() => {

--- a/src/utils/useIsScrolled/useIsScrolled.ts
+++ b/src/utils/useIsScrolled/useIsScrolled.ts
@@ -1,0 +1,46 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks whether the user has scrolled past a specified threshold.
+ *
+ * This hook is useful for showing/hiding navigation elements, implementing scroll-to-top
+ * buttons, or triggering animations based on scroll position.
+ *
+ * @example
+ * ```tsx
+ * // Basic usage - triggers on any scroll
+ * const isScrolled = useIsScrolled();
+ *
+ * // Custom threshold - triggers after scrolling 100px
+ * const hasScrolledPastHeader = useIsScrolled(100);
+ * ```
+ */
+export const useIsScrolled = (threshold = 0) => {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > threshold);
+    };
+
+    // Check initial scroll position to handle cases where the page is already scrolled on mount
+    handleScroll();
+
+    // Use passive listener since we're not calling preventDefault()
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [threshold]);
+
+  return isScrolled;
+};


### PR DESCRIPTION
# Add `useIsScrolled` hook

## :recycle: Current situation & Problem
We need a hook that tracks whether the user has scrolled past a specified threshold.

## :gear: Release Notes
Added a new hook in `src/utils/useIsScrolled/useIsScrolled.ts` that tracks whether the user has scrolled past a given threshold. The hook uses `useState` and `useEffect` to monitor scroll events and provides a boolean value (`true` if scrolled past the threshold).

## :white_check_mark: Testing
Created a test suite in `src/utils/useIsScrolled/useIsScrolled.test.ts` to validate the behavior of the `useIsScrolled` hook. Tests cover various scenarios, including initial states, custom thresholds, state updates, and proper cleanup of event listeners.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).