### PR TITLE
Create StatusDot component

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,10 @@
       "types": "./dist/components/SideLabel.d.ts",
       "default": "./dist/components/SideLabel.js"
     },
+    "./components/StatusDot": {
+      "types": "./dist/components/StatusDot.d.ts",
+      "default": "./dist/components/StatusDot.js"
+    },
     "./components/Switch": {
       "types": "./dist/components/Switch.d.ts",
       "default": "./dist/components/Switch.js"

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -7,6 +7,7 @@
 //
 
 import { type Meta, type StoryObj } from "@storybook/react";
+import { StatusDot } from "../StatusDot";
 import { Badge } from "./Badge";
 
 const meta: Meta<typeof Badge> = {
@@ -35,3 +36,34 @@ export const Outline: Story = { args: { variant: "outline" } };
 
 export const Sm: Story = { args: { size: "sm" } };
 export const Lg: Story = { args: { size: "lg" } };
+
+export const WithStatusDot: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      <Badge variant="outline">
+        <div className="flex items-center gap-2">
+          <StatusDot status="success" />
+          <span>Published</span>
+        </div>
+      </Badge>
+      <Badge variant="outline">
+        <div className="flex items-center gap-2">
+          <StatusDot status="default" />
+          <span>Draft</span>
+        </div>
+      </Badge>
+      <Badge variant="outline">
+        <div className="flex items-center gap-2">
+          <StatusDot status="warning" />
+          <span>Pending</span>
+        </div>
+      </Badge>
+      <Badge variant="outline">
+        <div className="flex items-center gap-2">
+          <StatusDot status="destructive" />
+          <span>Error</span>
+        </div>
+      </Badge>
+    </div>
+  ),
+};

--- a/src/components/StatusDot/StatusDot.stories.tsx
+++ b/src/components/StatusDot/StatusDot.stories.tsx
@@ -1,0 +1,69 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { type Meta, type StoryObj } from "@storybook/react";
+import { upperFirst } from "@/utils/misc";
+import { StatusDot } from "./StatusDot";
+
+const meta: Meta<typeof StatusDot> = {
+  title: "Components/StatusDot",
+  component: StatusDot,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StatusDot>;
+
+export const Default: Story = {
+  args: {
+    status: "default",
+  },
+};
+export const AllStatuses: Story = {
+  render: () => {
+    const statuses = [
+      "default",
+      "primary",
+      "success",
+      "warning",
+      "destructive",
+    ] as const;
+    return (
+      <div className="flex items-center gap-4">
+        {statuses.map((status) => (
+          <div key={status} className="flex flex-col items-center gap-2">
+            <StatusDot status={status} />
+            <span className="text-muted-foreground text-xs">
+              {upperFirst(status)}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => {
+    const sizes = [
+      { size: "sm", label: "Small" },
+      { size: "md", label: "Medium" },
+      { size: "lg", label: "Large" },
+    ] as const;
+    return (
+      <div className="flex items-center gap-4">
+        {sizes.map(({ size, label }) => (
+          <div key={size} className="flex flex-col items-center gap-2">
+            <StatusDot size={size} />
+            <span className="text-muted-foreground text-xs">{label}</span>
+          </div>
+        ))}
+      </div>
+    );
+  },
+};

--- a/src/components/StatusDot/StatusDot.test.tsx
+++ b/src/components/StatusDot/StatusDot.test.tsx
@@ -1,0 +1,54 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { render, screen } from "@testing-library/react";
+import { StatusDot } from "./StatusDot";
+
+describe("StatusDot", () => {
+  it("renders status dot element", () => {
+    render(<StatusDot />);
+
+    const element = screen.getByRole("img");
+
+    expect(element).toBeInTheDocument();
+  });
+
+  it("applies custom className correctly", () => {
+    render(<StatusDot className="custom-class" />);
+    expect(screen.getByRole("img")).toHaveClass("custom-class");
+  });
+
+  it("renders all status variants without errors", () => {
+    const statuses = [
+      "default",
+      "primary",
+      "success",
+      "warning",
+      "destructive",
+    ] as const;
+    statuses.forEach((status) => {
+      render(<StatusDot status={status} />);
+    });
+  });
+
+  it("applies the correct aria label", () => {
+    render(<StatusDot status="success" />);
+
+    const element = screen.getByRole("img");
+
+    expect(element).toHaveAttribute("aria-label", "Success status");
+  });
+
+  it("removes the aria label, if aria-hidden is true", () => {
+    render(<StatusDot status="success" aria-hidden />);
+
+    const element = screen.getByRole("img", { hidden: true });
+
+    expect(element).not.toHaveAttribute("aria-label");
+  });
+});

--- a/src/components/StatusDot/StatusDot.tsx
+++ b/src/components/StatusDot/StatusDot.tsx
@@ -1,0 +1,137 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { type ComponentProps } from "react";
+import { cn } from "@/utils/className";
+
+export const statusDotVariance = cva("rounded-full", {
+  variants: {
+    /**
+     * Controls the visual status of the dot.
+     * - `default`: neutral/inactive state
+     * - `primary`: active/enabled state
+     * - `success`: positive/successful state
+     * - `warning`: attention/caution state
+     * - `destructive`: negative/error state
+     *
+     * @default "default"
+     */
+    status: {
+      default: "bg-muted-foreground",
+      primary: "bg-primary",
+      success: "bg-success",
+      warning: "bg-warning",
+      destructive: "bg-destructive",
+    },
+    /**
+     * Controls the size of the status dot.
+     * - `sm`: size-2 (0.5rem) diameter
+     * - `md`: size-3 (0.75rem) diameter
+     * - `lg`: size-4 (1rem) diameter
+     *
+     * @default "sm"
+     */
+    size: {
+      sm: "size-2",
+      md: "size-3",
+      lg: "size-4",
+    },
+  },
+  defaultVariants: {
+    status: "default",
+    size: "sm",
+  },
+});
+
+export interface StatusDotProps
+  extends ComponentProps<"div">,
+    VariantProps<typeof statusDotVariance> {
+  /**
+   * Screen reader label for the status dot.
+   * If not provided, a default label will be generated based on the status.
+   */
+  "aria-label"?: string;
+  /**
+   * Whether the status dot should be hidden from screen readers.
+   * Use this when the status is already described by surrounding text.
+   *
+   * @default false
+   */
+  "aria-hidden"?: boolean;
+}
+
+/**
+ * A small visual indicator used to represent status, state, or activity.
+ * Status dots are commonly used in badges, lists, and other UI components
+ * to provide quick visual feedback about an item's state.
+ *
+ * @example
+ * // Basic status dot with automatic aria-label
+ * <StatusDot status="success" />
+ *
+ * @example
+ * // With custom aria-label
+ * <StatusDot status="success" aria-label="Task completed successfully" />
+ *
+ * @example
+ * // Hidden from screen readers when status is described elsewhere
+ * <StatusDot status="success" aria-hidden />
+ *
+ * @example
+ * // Different statuses
+ * <StatusDot status="primary" />
+ * <StatusDot status="warning" />
+ * <StatusDot status="destructive" />
+ *
+ * @example
+ * // Different sizes
+ * <StatusDot status="success" size="sm" />
+ * <StatusDot status="success" size="md" />
+ * <StatusDot status="success" size="lg" />
+ */
+export const StatusDot = ({
+  className,
+  status = "default",
+  size = "sm",
+  "aria-label": ariaLabel,
+  "aria-hidden": ariaHidden = false,
+  ...props
+}: StatusDotProps) => {
+  // Generate default aria-label based on status if not provided and not hidden
+  const getDefaultAriaLabel = (
+    statusValue: VariantProps<typeof statusDotVariance>["status"],
+  ) => {
+    if (!statusValue) {
+      return "Status indicator";
+    }
+
+    const statusLabels = {
+      default: "Neutral status",
+      primary: "Active status",
+      success: "Success status",
+      warning: "Warning status",
+      destructive: "Error status",
+    } as const;
+
+    return statusLabels[statusValue];
+  };
+
+  const effectiveAriaLabel =
+    ariaHidden ? undefined : (ariaLabel ?? getDefaultAriaLabel(status));
+
+  return (
+    <div
+      role="img"
+      aria-label={effectiveAriaLabel}
+      aria-hidden={ariaHidden}
+      className={cn(statusDotVariance({ status, size }), className)}
+      {...props}
+    />
+  );
+};

--- a/src/components/StatusDot/index.tsx
+++ b/src/components/StatusDot/index.tsx
@@ -1,0 +1,9 @@
+//
+// This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+export * from "./StatusDot";

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export * from "./components/ScrollArea";
 export * from "./components/Select";
 export * from "./components/Separator";
 export * from "./components/SideLabel";
+export * from "./components/StatusDot";
 export * from "./components/Switch";
 export * from "./components/Sheet";
 export * from "./components/Radio";


### PR DESCRIPTION
# Create StatusDot component

<img width="1506" height="818" alt="image" src="https://github.com/user-attachments/assets/9423647b-e9e2-4dca-bf3f-443476650edc" />

## :recycle: Current situation & Problem
Badges often come in "outline" or "ghost" variant, but with colorful status dots inside.

## :gear: Release Notes
* Added the `StatusDot` component in `src/components/StatusDot/StatusDot.tsx` with support for multiple statuses, sizes and accessibility features.
* Created Storybook stories for `StatusDot`, showcasing all statuses and sizes, in `src/components/StatusDot/StatusDot.stories.tsx`.
* Added tests for `StatusDot` to ensure correct rendering, class application, status variants, and accessibility attributes in `src/components/StatusDot/StatusDot.test.tsx`.
* Updated `Badge` component stories to include examples of using `StatusDot` within badges in `src/components/Badge/Badge.stories.tsx`. [[1]](diffhunk://#diff-0532698a6747ca92ee2fd82d5478b60589d49ecec9b765d6364b9badf6ef1803R10) [[2]](diffhunk://#diff-0532698a6747ca92ee2fd82d5478b60589d49ecec9b765d6364b9badf6ef1803R39-R69)
* 
## :white_check_mark: Testing
Added unit tests and storybook examples.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).