### PR TITLE
Pass padding through an Async component to StateContainer

### DIFF
--- a/src/components/Async/Async.stories.tsx
+++ b/src/components/Async/Async.stories.tsx
@@ -34,3 +34,7 @@ export const CustomMessage: Story = {
 export const Empty: Story = {
   args: { empty: { show: true } },
 };
+
+export const NoPadding: Story = {
+  args: { empty: true, padding: false },
+};

--- a/src/components/Async/Async.tsx
+++ b/src/components/Async/Async.tsx
@@ -43,7 +43,8 @@ export type FullErrorProps = {
   show: boolean;
 } & ErrorStateProps;
 
-export interface AsyncProps extends Pick<StateContainerProps, "grow"> {
+export interface AsyncProps
+  extends Pick<StateContainerProps, "grow" | "padding"> {
   /**
    * This is the main content that will be shown when there is no error,
    * loading, or empty state.
@@ -161,6 +162,7 @@ export const Async = ({
   children,
   grow,
   className,
+  padding,
 }: AsyncProps) => {
   const error = parseError(errorProp);
   const empty = parseEmpty(emptyProp);
@@ -176,7 +178,7 @@ export const Async = ({
   return (
     !specialState ? children
     : renderState ? renderState(specialState)
-    : <StateContainer grow={grow} className={className}>
+    : <StateContainer grow={grow} className={className} padding={padding}>
         {specialState}
       </StateContainer>
   );


### PR DESCRIPTION
# Pass padding through an Async component to StateContainer

<img width="275" height="128" alt="image" src="https://github.com/user-attachments/assets/f2113175-a0ce-487e-9f29-a04bee43c881" />


## :recycle: Current situation & Problem
Sometimes `Async` needs padding to be disabled. 


## :gear: Release Notes
* Pass padding through an Async component to StateContainer


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
