### PR TITLE
Adjust useForm to work with zod v4 schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@stanfordspezi/spezi-web-design-system",
       "license": "MIT",
       "dependencies": {
-        "@hookform/resolvers": "^5.0.1",
+        "@hookform/resolvers": "^5.2.1",
         "@nextui-org/use-pagination": "^2.2.3",
         "@tanstack/match-sorter-utils": "^8.19.4",
         "@tanstack/react-query": "^5.83.1",
@@ -1934,9 +1934,9 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.0.1.tgz",
-      "integrity": "sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+      "integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/utils": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -305,7 +305,7 @@
     "prepush": "npm run lint:fix && tsc --noEmit"
   },
   "dependencies": {
-    "@hookform/resolvers": "^5.0.1",
+    "@hookform/resolvers": "^5.2.1",
     "@nextui-org/use-pagination": "^2.2.3",
     "@tanstack/match-sorter-utils": "^8.19.4",
     "@tanstack/react-query": "^5.83.1",

--- a/src/forms/Field/Field.stories.tsx
+++ b/src/forms/Field/Field.stories.tsx
@@ -8,10 +8,10 @@
 
 import { type Meta } from "@storybook/react";
 import { z } from "zod";
-import { LabelContainer, Label as LabelComponent } from "@/components/Label";
-import { Field } from "./Field";
+import { Label as LabelComponent, LabelContainer } from "@/components/Label";
 import { Input } from "../../components/Input";
 import { useForm } from "../useForm";
+import { Field } from "./Field";
 
 const meta: Meta<typeof Field> = {
   title: "Forms/Field",
@@ -52,16 +52,13 @@ export const Label = () => {
  * This is just example
  */
 export const Error = () => {
-  const form = useForm({
-    formSchema,
-    errors: {
-      name: { message: "Name is required field", type: "validationError" },
-    },
-  });
+  const form = useForm({ formSchema });
   return (
     <Field
       control={form.control}
       name="name"
+      label="Name"
+      error={{ message: "Name is required field", type: "validationError" }}
       render={({ field }) => <Input {...field} />}
     />
   );

--- a/src/forms/useForm/useForm.test.ts
+++ b/src/forms/useForm/useForm.test.ts
@@ -6,8 +6,10 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { renderHook, act } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { z } from "zod";
+import * as z3 from "zod/v3";
+import * as z4 from "zod/v4";
 import { useForm } from "./useForm";
 
 describe("useForm", () => {
@@ -61,5 +63,93 @@ describe("useForm", () => {
     });
     const data = await result.current.submitAsync();
     expect(data).toEqual({ value: "some" });
+  });
+
+  describe("Zod v3 and v4 compatibility", () => {
+    it("works with standard Zod v3 schemas", async () => {
+      const schema = z3.object({
+        email: z3.string().email(),
+        age: z3.number().min(18),
+        name: z3.string().min(1),
+      });
+
+      const { result } = renderHook(() =>
+        useForm({
+          formSchema: schema,
+          defaultValues: {
+            email: "",
+            age: 0,
+            name: "",
+          },
+        }),
+      );
+
+      act(() => {
+        result.current.setValue("email", "invalid-email");
+        result.current.setValue("age", 16);
+        result.current.setValue("name", "");
+      });
+
+      await act(async () => {
+        await expect(result.current.submitAsync()).rejects.toThrow();
+      });
+
+      // Test that valid data passes validation
+      act(() => {
+        result.current.setValue("email", "test@example.com");
+        result.current.setValue("age", 25);
+        result.current.setValue("name", "John Doe");
+      });
+
+      const data = await result.current.submitAsync();
+      expect(data).toEqual({
+        email: "test@example.com",
+        age: 25,
+        name: "John Doe",
+      });
+    });
+
+    it("works with standard Zod v4 schemas", async () => {
+      const schema = z4.object({
+        email: z4.email(),
+        age: z4.number().min(18),
+        name: z4.string().min(1),
+      });
+
+      const { result } = renderHook(() =>
+        useForm({
+          formSchema: schema,
+          defaultValues: {
+            email: "",
+            age: 0,
+            name: "",
+          },
+        }),
+      );
+
+      act(() => {
+        result.current.setValue("email", "invalid-email");
+        result.current.setValue("age", 16);
+        result.current.setValue("name", "");
+      });
+
+      await act(async () => {
+        await expect(result.current.submitAsync()).rejects.toThrow();
+      });
+
+      // Test that valid data passes validation
+      act(() => {
+        result.current.setValue("email", "test@example.com");
+        result.current.setValue("age", 25);
+        result.current.setValue("name", "John Doe");
+      });
+
+      const data = await result.current.submitAsync();
+      expect(data).toEqual({
+        email: "test@example.com",
+        age: 25,
+        name: "John Doe",
+      });
+    });
   });
 });


### PR DESCRIPTION
# Adjust useForm to work with zod v4 schemas

## :recycle: Current situation & Problem
Right now, only zod v3 schemas work with the `useForm` hook.

## :gear: Release Notes

**Main changes**

* Refactored `useForm` in `src/forms/useForm/useForm.ts` to support both Zod v3 and v4 schemas.
* Updated `@hookform/resolvers` dependency in `package.json` from version `^5.0.1` to `^5.2.1` to ensure compatibility with both Zod v3 and v4.

**Other Improvements:**

* Noticed that the `Error` story in `src/forms/Field/Field.stories.tsx` caused infinite rerenders. Decided to pass error props directly to the `Field` component.

## :white_check_mark: Testing
Added tests in `src/forms/useForm/useForm.test.ts` to verify that the `useForm` hook works correctly with both Zod v3 and v4 schemas.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).