### PR TITLE
Add helpers from the study platform

### DIFF
--- a/src/utils/misc/misc.test.ts
+++ b/src/utils/misc/misc.test.ts
@@ -96,4 +96,8 @@ describe("joinPaths", () => {
   it("supports numeric segments", () => {
     expect(joinPaths("/users", 42)).toBe("/users/42");
   });
+
+  it("returns empty string when all segments are empty", () => {
+    expect(joinPaths("", null, undefined, "")).toBe("");
+  });
 });

--- a/src/utils/misc/misc.test.ts
+++ b/src/utils/misc/misc.test.ts
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { not, times, upperFirst, isObject, isEmpty } from "./misc";
+import { isEmpty, isObject, joinPaths, not, times, upperFirst } from "./misc";
 
 describe("not", () => {
   it("negates value", () => {
@@ -66,5 +66,36 @@ describe("isEmpty", () => {
     [new Set(), true],
   ])("checks if %s is empty -> %s", (a, result) => {
     expect(isEmpty(a)).toEqual(result);
+  });
+});
+
+describe("joinPaths", () => {
+  it("joins basic segments", () => {
+    expect(joinPaths("/api/v1/", "/users", "123")).toBe("/api/v1/users/123");
+  });
+
+  it("collapses duplicate slashes between segments", () => {
+    expect(joinPaths("/api//", "//v1///", "users")).toBe("/api/v1/users");
+  });
+
+  it("preserves absolute URL bases", () => {
+    expect(joinPaths("https://example.com/", "/users/", "123")).toBe(
+      "https://example.com/users/123",
+    );
+  });
+
+  it("keeps query and hash on the last segment", () => {
+    expect(joinPaths("/api", "users?x=1#top")).toBe("/api/users?x=1#top");
+    expect(joinPaths("/api/", "users/?x=1#top")).toBe("/api/users/?x=1#top");
+  });
+
+  it("ignores null/undefined/empty segments", () => {
+    // Current implementation treats empty strings as removable only after trimming slashes.
+    // If you adopt the simplified version that filters empty strings, this still passes.
+    expect(joinPaths(undefined, "", "/a/", null, "b")).toBe("/a/b");
+  });
+
+  it("supports numeric segments", () => {
+    expect(joinPaths("/users", 42)).toBe("/users/42");
   });
 });

--- a/src/utils/misc/misc.test.ts
+++ b/src/utils/misc/misc.test.ts
@@ -90,8 +90,6 @@ describe("joinPaths", () => {
   });
 
   it("ignores null/undefined/empty segments", () => {
-    // Current implementation treats empty strings as removable only after trimming slashes.
-    // If you adopt the simplified version that filters empty strings, this still passes.
     expect(joinPaths(undefined, "", "/a/", null, "b")).toBe("/a/b");
   });
 

--- a/src/utils/misc/misc.ts
+++ b/src/utils/misc/misc.ts
@@ -71,6 +71,18 @@ export type RequiredSome<T, K extends keyof T> = Partial<Omit<T, K>> &
   Required<Pick<T, K>>;
 
 /**
+ * Prettify makes complex object types easier to read by flattening intersections.
+ * Use this when you export or inspect inferred types. This only affects type presentation in tooling.
+ *
+ * @example
+ * type A = { a: string };
+ * type B = { b: number };
+ * type Mixed = A & B;
+ * type Readable = Prettify<Mixed>; // { a: string; b: number }
+ */
+export type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+/**
  * Handles copying to clipboard and show confirmation toast.
  */
 export const copyToClipboard = async (value: string) => {
@@ -188,3 +200,54 @@ export const formatBoolean = (value: boolean) => (value ? "true" : "false");
  */
 export const formatNilBoolean = (value: Nil<boolean>) =>
   isNil(value) ? null : formatBoolean(value);
+
+/**
+ * Joins path segments, handling leading/trailing slashes between segments.
+ * It accepts strings and numbers; ignores null/undefined/empty segments.
+ *
+ * @example
+ * joinPaths("/api/v1/", "/users", "123"); // "/api/v1/users/123"
+ *
+ * @example
+ * joinPaths("api", "users"); // "api/users"
+ *
+ * @example
+ * joinPaths("https://example.com/", "/users/", "123"); // "https://example.com/users/123"
+ *
+ * @example
+ * joinPaths("/a", "b?x=1#top"); // "/a/b?x=1#top"
+ */
+export const joinPaths = (
+  ...segments: Array<string | number | null | undefined>
+): string => {
+  const normalizedSegments = segments
+    .filter(
+      (segment): segment is string | number =>
+        segment != null && String(segment).length > 0,
+    )
+    .map((segment) => String(segment))
+    .map((segment, index, arr) => {
+      const isFirstSegment = index === 0;
+      const isLastSegment = index === arr.length - 1;
+
+      // Remove leading slashes from non-first segments to avoid "//" in the middle.
+      const withoutLeadingSlash =
+        isFirstSegment ? segment : segment.replace(/^\/+/, "");
+
+      // Remove trailing slashes from non-last segments to avoid duplicate separators.
+      const withoutTrailingSlash =
+        isLastSegment ? withoutLeadingSlash : (
+          withoutLeadingSlash.replace(/\/+$/, "")
+        );
+
+      return withoutTrailingSlash;
+    })
+    // Remove any segments that became empty after trimming (e.g., a standalone "/")
+    .filter((segment) => segment.length > 0);
+
+  if (normalizedSegments.length === 0) {
+    return "";
+  }
+
+  return normalizedSegments.join("/");
+};

--- a/src/utils/misc/misc.ts
+++ b/src/utils/misc/misc.ts
@@ -217,15 +217,13 @@ export const formatNilBoolean = (value: Nil<boolean>) =>
  * @example
  * joinPaths("/a", "b?x=1#top"); // "/a/b?x=1#top"
  */
-export const joinPaths = (
-  ...segments: Array<string | number | null | undefined>
-): string => {
+export const joinPaths = (...segments: Array<Nil<string | number>>) => {
   const normalizedSegments = segments
     .filter(
       (segment): segment is string | number =>
-        segment != null && String(segment).length > 0,
+        !isNil(segment) && String(segment).length > 0,
     )
-    .map((segment) => String(segment))
+    .map(String)
     .map((segment, index, arr) => {
       const isFirstSegment = index === 0;
       const isLastSegment = index === arr.length - 1;


### PR DESCRIPTION
# Add helpers from the study platform

## :recycle: Current situation & Problem
Some utils from the study platform could be useful in this repo.

## :gear: Release Notes
* Added the `Prettify` type in `misc.ts` to flatten complex intersection types, making them easier to read in tooling and type inspection.
* Added `joinPaths` function to `misc.ts`, which joins path segments while handling leading/trailing slashes, supports strings and numbers, and ignores empty/null/undefined segments.


## :white_check_mark: Testing
Added unit tests for `joinPaths` in `misc.test.ts`, covering various edge cases such as duplicate slashes, absolute URLs, query/hash preservation, and numeric segments. 

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).