### PR TITLE
Make DashedSeparator styles more robust

### DIFF
--- a/src/components/Separator/DashedSeparator/DashedSeparator.tsx
+++ b/src/components/Separator/DashedSeparator/DashedSeparator.tsx
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import { cn } from "@/utils/className";
 import type { CSSProperties, ComponentProps } from "react";
+import { cn } from "@/utils/className";
 import { Separator } from "../Separator";
 
 interface DashedSeparatorProps extends ComponentProps<typeof Separator> {

--- a/src/components/Separator/DashedSeparator/DashedSeparator.tsx
+++ b/src/components/Separator/DashedSeparator/DashedSeparator.tsx
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import type { CSSProperties, ComponentProps } from "react";
 import { cn } from "@/utils/className";
+import type { CSSProperties, ComponentProps } from "react";
 import { Separator } from "../Separator";
 
 interface DashedSeparatorProps extends ComponentProps<typeof Separator> {
@@ -77,8 +77,10 @@ export const DashedSeparator = ({
   <Separator
     orientation={orientation}
     className={cn(
+      // We need this CSS variable so the bg class is applied in projects without a 'border' color var in the Tailwind config
+      "[--default-border-color:theme(colors.border)]",
       orientation === "vertical" ? "[--tilt:0deg]" : "[--tilt:90deg]",
-      "bg-[linear-gradient(var(--tilt),var(--dash-color,theme(colors.border)),var(--dash-color,theme(colors.border))_calc(100%_-_var(--dash-gap,theme(spacing.1))),transparent_calc(100%_-_var(--dash-gap,theme(spacing.1))),transparent_100%)]",
+      "bg-[linear-gradient(var(--tilt),var(--dash-color,var(--default-border-color)),var(--dash-color,var(--default-border-color))_calc(100%_-_var(--dash-gap,theme(spacing.1))),transparent_calc(100%_-_var(--dash-gap,theme(spacing.1))),transparent_100%)]",
       "bg-[length:var(--dash-size,theme(spacing.4))_var(--dash-size,theme(spacing.4))]",
       className,
     )}


### PR DESCRIPTION
# Make DashedSeparator styles more robust

## :recycle: Current situation & Problem
The background color class of the `DashedSeparator` component is not picked up by Tailwind, if there is no 'border' color variable in the Tailwind config. Mysteriously, the styles are also not applied if there is a "--color-border" variable in a Tailwind v4 project.

Try for yourself: https://play.tailwindcss.com/YvxAVGZVFZ

## :gear: Release Notes
Added a CSS variable (`--default-border-color`) to ensure the application of the `DashedSeparator` background color class is not dependent on successful parsing of `theme(colors.border)`

## :white_check_mark: Testing
Made sure that the style is still applied correctly in the storyboard setup and that this solution works in Tailwind v4.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).