### PR TITLE
Remove theme variables injection

### DIFF
--- a/src/SpeziProvider.tsx
+++ b/src/SpeziProvider.tsx
@@ -11,12 +11,9 @@ import {
   createContext,
   type ReactNode,
   useContext,
-  useLayoutEffect,
   useMemo,
 } from "react";
 import { messages as defaultMessages, type AllMessages } from "@/messages";
-import { lightTheme } from "@/theme/light";
-import { type Theme } from "@/theme/utils";
 
 /**
  * Allows injecting the necessary router-related components.
@@ -58,10 +55,6 @@ export const useSpeziContext = () => {
 interface SpeziProviderProps extends SpeziContextType {
   children?: ReactNode;
   /**
-   * Allows customizing default CSS variables for the theme.
-   */
-  theme?: Partial<Theme>;
-  /**
    * Allows overriding default localization messages.
    */
   messages?: Partial<AllMessages>;
@@ -102,18 +95,8 @@ interface SpeziProviderProps extends SpeziContextType {
 export const SpeziProvider = ({
   children,
   messages,
-  theme,
   router,
 }: SpeziProviderProps) => {
-  useLayoutEffect(() => {
-    const resolvedTheme = { ...lightTheme, ...theme };
-    Object.entries(resolvedTheme).forEach(([key, value]) => {
-      if (value) {
-        document.documentElement.style.setProperty(`--${key}`, value);
-      }
-    });
-  }, [theme]);
-
   const resolvedMessages = useMemo(
     () => ({ ...defaultMessages, ...messages }),
     [messages],

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -11,34 +11,43 @@ SPDX-License-Identifier: MIT
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@theme {
-  --color-surface: var(--color-surface);
-  --color-surface-primary: var(--color-surface-primary);
-  --color-foreground: var(--color-foreground);
-  --color-card: var(--color-card);
-  --color-card-foreground: var(--color-card-foreground);
-  --color-popover: var(--color-popover);
-  --color-popover-foreground: var(--color-popover-foreground);
-  --color-primary: var(--color-primary);
-  --color-primary-foreground: var(--color-primary-foreground);
-  --color-secondary: var(--color-secondary);
-  --color-secondary-foreground: var(--color-secondary-foreground);
-  --color-muted: var(--color-muted);
-  --color-muted-foreground: var(--color-muted-foreground);
-  --color-accent: var(--color-accent);
-  --color-accent-foreground: var(--color-accent-foreground);
-  --color-border: var(--color-border);
-  --color-input: var(--color-input);
-  --color-success: var(--color-success);
-  --color-success-foreground: var(--color-success-foreground);
-  --color-warning: var(--color-warning);
-  --color-warning-dark: var(--color-warning-dark);
-  --color-warning-foreground: var(--color-warning-foreground);
-  --color-destructive: var(--color-destructive);
-  --color-destructive-foreground: var(--color-destructive-foreground);
-  --color-inverted: var(--color-inverted);
-  --color-inverted-foreground: var(--color-inverted-foreground);
-  --color-ring: var(--color-ring);
+@theme inline {
+  --color-surface: var(--color-surface, rgb(250 250 249));
+  --color-surface-primary: var(--color-surface-primary, rgb(255 255 255));
+  --color-foreground: var(--color-foreground, rgb(9 4 4));
+  --color-card: var(--color-card, rgb(255 255 255));
+  --color-card-foreground: var(--color-card-foreground, rgb(9 4 4));
+  --color-popover: var(--color-popover, rgb(255 255 255));
+  --color-popover-foreground: var(--color-popover-foreground, rgb(9 4 4));
+  --color-primary: var(--color-primary, rgb(62 176 85));
+  --color-primary-foreground: var(--color-primary-foreground, rgb(243 243 243));
+  --color-secondary: var(--color-secondary, rgb(242 240 240));
+  --color-secondary-foreground: var(
+    --color-secondary-foreground,
+    rgb(30 15 15)
+  );
+  --color-muted: var(--color-muted, rgb(242 240 240));
+  --color-muted-foreground: var(--color-muted-foreground, rgb(159 159 159));
+  --color-accent: var(--color-accent, rgb(242 240 240));
+  --color-accent-foreground: var(--color-accent-foreground, rgb(30 15 15));
+  --color-border: var(--color-border, rgb(232 215 221));
+  --color-input: var(--color-input, rgb(232 215 221));
+  --color-destructive: var(--color-destructive, rgb(222 65 38));
+  --color-destructive-foreground: var(
+    --color-destructive-foreground,
+    rgb(243 243 243)
+  );
+  --color-success: var(--color-success, rgb(34 197 94));
+  --color-success-foreground: var(--color-success-foreground, rgb(243 243 243));
+  --color-warning: var(--color-warning, rgb(252 211 3));
+  --color-warning-dark: var(--color-warning-dark, rgb(153 101 21));
+  --color-warning-foreground: var(--color-warning-foreground, rgb(9 4 4));
+  --color-inverted: var(--color-inverted, rgb(9 4 4));
+  --color-inverted-foreground: var(
+    --color-inverted-foreground,
+    rgb(243 243 243)
+  );
+  --color-ring: var(--color-ring, rgb(62 176 85));
 }
 
 @utility focus-ring {


### PR DESCRIPTION
# Remove theme variables injection

## :recycle: Current situation & Problem
Closes #83 


## :gear: Release Notes
* Remove theme variables injection


## :books: Documentation
Tailwind v4 relies on CSS variables for theming, thus there is no need to maintain previous variables injection system. 


## :white_check_mark: Testing
Tested with ENGAGE-HF.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
