### PR TITLE
Forward id from Select to SelectTrigger

### DIFF
--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -40,6 +40,38 @@ window.HTMLElement.prototype.hasPointerCapture = vitest.fn();
 const queryItem = (value: string) => screen.queryAllByText(value).at(1);
 
 describe("Select", () => {
+  it("forwards id from Select to SelectTrigger", () => {
+    render(
+      <Select id="test-id">
+        <SelectTrigger>
+          <SelectValue placeholder="Organizations" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="Lorem">Lorem</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    const trigger = screen.getByRole("combobox");
+    expect(trigger).toHaveAttribute("id", "test-id");
+  });
+
+  it("allows SelectTrigger id prop to override Select id", () => {
+    render(
+      <Select id="select-id">
+        <SelectTrigger id="trigger-id">
+          <SelectValue placeholder="Organizations" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="Lorem">Lorem</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    const trigger = screen.getByRole("combobox");
+    expect(trigger).toHaveAttribute("id", "trigger-id");
+  });
+
   it("renders accessible select", async () => {
     render(
       <Select>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -90,6 +90,11 @@ interface SelectContextProps {
    */
   formatValue?: (value: string) => ReactNode;
   disabled?: boolean;
+  /**
+   * HTML id attribute forwarded to SelectTrigger.
+   * Useful for associating a label with the select trigger via `htmlFor`.
+   */
+  id?: string;
 }
 
 interface SelectProps extends SelectContextProps {
@@ -150,6 +155,7 @@ export const useSelectProvider = ({
   search,
   disabled,
   formatValue,
+  id,
 }: SelectContextProps) => {
   const [open, setOpen] = useState(false);
   const [selectedValue, setSelectedValue] = useState<string | undefined>(
@@ -188,6 +194,7 @@ export const useSelectProvider = ({
     search: normalizeSearchProp(search),
     disabled,
     formatValue,
+    id,
   };
 };
 
@@ -330,14 +337,16 @@ export const SelectTrigger = ({
   "aria-expanded": propsAriaExpanded,
   className,
   children,
+  id: propsId,
   ...props
 }: SelectTriggerProps) => {
-  const { open, disabled } = useSelectContext();
+  const { open, disabled, id: contextId } = useSelectContext();
 
   return (
     <PopoverTrigger asChild>
       <Button
         {...props}
+        id={propsId ?? contextId}
         role={role}
         size={null}
         variant={null}


### PR DESCRIPTION
## :recycle: Current situation & Problem
The `Select` component doesn't forward its `id` prop to the underlying `SelectTrigger`, making it difficult to associate a `<label>` with the select trigger via `htmlFor`.

Closes #33 

## :gear: Release Notes
- Added `id` prop to `Select` that is forwarded to `SelectTrigger`, enabling `<label htmlFor="...">` association
- `SelectTrigger`'s own `id` prop takes precedence over the one from `Select`

## :books: Documentation
The new `id` prop on `SelectContextProps` is documented with JSDoc inline.

## :white_check_mark: Testing
- Added test verifying `id` is forwarded from `Select` to `SelectTrigger`
- Added test verifying `SelectTrigger`'s own `id` overrides the `Select` one

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The Select component now accepts an `id` prop that automatically forwards to the underlying trigger, enabling improved label association and accessibility.

* **Tests**
  * Added tests to verify id prop forwarding behavior and override capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->