### PR TITLE
Add checkEmptyError stories for Field component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,11 @@
+<!--
+This source file is part of the Stanford Biodesign Digital Health Spezi Web Design System open-source project
+
+SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+-->
+
 # CLAUDE.md
 
 ## REUSE License Headers

--- a/src/forms/Field/Field.stories.tsx
+++ b/src/forms/Field/Field.stories.tsx
@@ -84,7 +84,7 @@ interface CheckEmptyErrorProps {
 }
 
 const CheckEmptyError = ({ checkEmptyError }: CheckEmptyErrorProps) => {
-  const error = useOpenState();
+  const errorVisibility = useOpenState();
   const form = useForm({ formSchema });
   return (
     <div>
@@ -93,24 +93,24 @@ const CheckEmptyError = ({ checkEmptyError }: CheckEmptyErrorProps) => {
         name="name"
         label="Field with error"
         error={
-          error.isOpen ?
-            { message: "Name is required field", type: "validationError" }
+          errorVisibility.isOpen ?
+            { message: "Name is a required field", type: "validationError" }
           : undefined
         }
         checkEmptyError={checkEmptyError}
         render={({ field }) => <Input {...field} />}
       />
-      <Button onClick={error.toggle}>
-        {error.isOpen ? "Hide" : "Show"} error
+      <Button onClick={errorVisibility.toggle}>
+        {errorVisibility.isOpen ? "Hide" : "Show"} error
       </Button>
     </div>
   );
 };
 
 /**
- * By default, Field reserves space for the error message even when there is no error,
- * preventing layout shifts. The text below the fields stays in a fixed position
- * regardless of whether errors are shown.
+ * By default, Field reserves minimum space for the error message even when there is no error,
+ * which helps reduce layout shifts for typical single-line errors. The text below the fields
+ * is less likely to move when errors are shown or hidden.
  */
 export const CheckEmptyErrorOff = () => (
   <CheckEmptyError checkEmptyError={false} />

--- a/src/forms/Field/Field.tsx
+++ b/src/forms/Field/Field.tsx
@@ -47,8 +47,9 @@ export type FieldProps<
   label?: ReactNode;
   className?: string;
   /**
-   * Whether to check for empty errors.
-   * Empty error establishes a standard gap between form fields.
+   * Controls handling of empty error messages.
+   * When false (default), an empty {@link Error} element is rendered to maintain a standard gap between form fields.
+   * When true, the empty error element is not rendered and this additional spacing is removed.
    * For more details, refer to the {@link ErrorProps#checkEmpty|checkEmpty} property of the {@link Error} component.
    */
   checkEmptyError?: boolean;


### PR DESCRIPTION
## :recycle: Current situation & Problem
The `checkEmptyError` prop on the `Field` component had no Storybook stories demonstrating its behavior. It was unclear from documentation alone how it affects layout spacing.

## :gear: Release Notes
- Add `CheckEmptyErrorOff` and `CheckEmptyErrorOn` stories to the Field component, with an interactive toggle button to visualize the layout difference
- Clarify `checkEmptyError` JSDoc to mention that the empty error establishes a standard gap between form fields

## :books: Documentation
Updated JSDoc for `checkEmptyError` prop. No public API changes.

## :white_check_mark: Testing
Stories serve as visual tests. No unit test changes needed.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added SPDX license metadata and normalized trailing newline in the repo docs.
  * Clarified Field component docs to explain how empty error content affects spacing.

* **Stories**
  * Added Storybook stories showing Field error rendering with `checkEmptyError` toggled, illustrating differing layout/spacing behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->