### PR TITLE
Use bg-surface background in Storybook canvas

### DIFF
--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -10,3 +10,7 @@ SPDX-License-Identifier: MIT
 
 @import "../src/tailwind.css";
 @import "../src/base.css";
+
+.sb-show-main {
+  @apply bg-surface;
+}


### PR DESCRIPTION
## :recycle: Current situation & Problem
Storybook canvas uses a default white background, while Spezi Web Design System apps use `bg-surface` as their base surface color. This mismatch means components are previewed against a different background than they'd appear in production.

## :gear: Release Notes
- Apply `bg-surface` background to Storybook canvas (`.sb-show-main`) so component previews match the actual app surface color.

## :books: Documentation
No public API changes.

## :white_check_mark: Testing
Verified visually in Storybook that the canvas background matches `bg-surface` (`rgb(250, 250, 249)`).

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the main display area styling in Storybook to apply a consistent surface background color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->