### PR TITLE
Improve Storybook launch config for Claude Code

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,8 +3,8 @@
   "configurations": [
     {
       "name": "storybook",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "storybook"],
+      "runtimeExecutable": "sh",
+      "runtimeArgs": ["-c", "npx storybook dev -p ${PORT:-6006} --ci --no-open"],
       "port": 6006,
       "autoPort": true
     },


### PR DESCRIPTION
## :recycle: Current situation & Problem
The Storybook launch configuration in `.claude/launch.json` doesn't properly support `autoPort` — the `PORT` env variable isn't injected into the Storybook command. It also opens a browser tab on every start and shows interactive port-conflict prompts that block CI-like usage.

## :gear: Release Notes
- Use `$PORT` env variable in Storybook launch command so `autoPort` works correctly
- Add `--ci` flag to disable interactive prompts on port conflicts
- Add `--no-open` flag to prevent auto-opening a browser tab

## :books: Documentation
No public API changes.

## :white_check_mark: Testing
Verified Storybook starts on the auto-assigned port without interactive prompts or browser tab opening.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Storybook development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->