### PR TITLE
Use native root error support in useForm

### DIFF
--- a/src/forms/FormError/FormError.tsx
+++ b/src/forms/FormError/FormError.tsx
@@ -8,7 +8,7 @@
 
 import { isString } from "es-toolkit";
 import { type ReactNode } from "react";
-import { type ErrorOption } from "react-hook-form";
+import { type GlobalError } from "react-hook-form";
 import { ErrorState, type ErrorStateProps } from "@/components/ErrorState";
 import { StateContainer } from "@/components/StateContainer";
 import { cn } from "@/utils/className";
@@ -16,7 +16,7 @@ import { isObject } from "@/utils/misc";
 
 export interface FormErrorProps
   extends Omit<ErrorStateProps, "children" | "prefix" | "entityName"> {
-  formError: ErrorOption | ReactNode;
+  formError: GlobalError | ReactNode;
   prefix?: ReactNode;
 }
 

--- a/src/forms/useForm/useForm.ts
+++ b/src/forms/useForm/useForm.ts
@@ -10,7 +10,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useCallback } from "react";
 import {
   type DeepRequired,
-  type ErrorOption,
   type FieldErrorsImpl,
   useForm as useFormHook,
   type UseFormProps,
@@ -23,11 +22,6 @@ type FieldValues = Record<string, unknown>;
 type ErrorsObject<TFieldValues extends FieldValues> = Partial<
   FieldErrorsImpl<DeepRequired<TFieldValues>>
 >;
-
-/**
- * Special key used for form-level errors.
- */
-export const FORM_ERROR_KEY = "FORM_ERROR";
 
 /**
  * Custom error class for form validation errors.
@@ -110,12 +104,7 @@ export const useForm = <
       const errorValue = {
         message: parseUnknownError(error),
       };
-      setError(
-        // @ts-expect-error Form error is a special key, so type error here is expected
-        FORM_ERROR_KEY,
-        errorValue,
-        options,
-      );
+      setError("root", errorValue, options);
     },
     [setError],
   );
@@ -136,7 +125,7 @@ export const useForm = <
       }
     }, negativeHandler);
 
-  const formError = errors[FORM_ERROR_KEY] as ErrorOption | undefined;
+  const formError = errors.root;
 
   const isSubmitDisabled = !isValid || !isDirty;
 


### PR DESCRIPTION
## :recycle: Current situation & Problem
The `useForm` hook used a custom `FORM_ERROR_KEY` constant to store form-level errors via `setError`. This required a `@ts-expect-error` directive and a manual type cast since the key wasn't part of the form schema. React Hook Form natively supports root errors via `setError("root", ...)` and `errors.root`.

## :gear: Release Notes
- Replaced custom `FORM_ERROR_KEY` with react-hook-form's built-in `setError("root", ...)` and `errors.root`
- Removed exported `FORM_ERROR_KEY` constant (breaking change if consumed externally)
- Updated `FormError` prop type from `ErrorOption` to `GlobalError`

## :books: Documentation
No public API changes beyond removing the `FORM_ERROR_KEY` export. The `formError` and `setFormError` APIs remain unchanged.

## :white_check_mark: Testing
All existing useForm and FormError tests pass without modifications.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced form error handling with updated type definitions to better support server-side error scenarios and streamlined internal error management mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->