### PR TITLE
Remove redundant Fragment from MenuItem

### DIFF
--- a/src/molecules/DashboardLayout/MenuItem.tsx
+++ b/src/molecules/DashboardLayout/MenuItem.tsx
@@ -74,35 +74,33 @@ export const MenuItem = ({
   } = useSpeziContext();
 
   const content = (
-    <>
-      <Link
-        href={href}
-        data-slot="menu-item"
-        className={cn(
-          "focus-ring relative flex items-center gap-3 rounded-lg p-2 font-medium no-underline transition",
-          isActive ?
-            "bg-accent/50 text-primary hover:opacity-60"
-          : "text-foreground/60 hover:bg-accent hover:text-foreground",
-          shrinkable ? "xl:w-full xl:self-start" : "lg:w-full lg:self-start",
-        )}
-      >
-        {icon}
-        <span className={cn("grow", shrinkable && "lg:hidden xl:block")}>
-          {label}
-        </span>
-        {children}
-        {isHighlighted && (
-          <i
-            aria-hidden
-            className={cn(
-              "bg-destructive size-2.5 rounded-full",
-              shrinkable &&
-                "lg:absolute lg:top-1 lg:right-1 lg:size-1.5 xl:static xl:size-2.5",
-            )}
-          />
-        )}
-      </Link>
-    </>
+    <Link
+      href={href}
+      data-slot="menu-item"
+      className={cn(
+        "focus-ring relative flex items-center gap-3 rounded-lg p-2 font-medium no-underline transition",
+        isActive ?
+          "bg-accent/50 text-primary hover:opacity-60"
+        : "text-foreground/60 hover:bg-accent hover:text-foreground",
+        shrinkable ? "xl:w-full xl:self-start" : "lg:w-full lg:self-start",
+      )}
+    >
+      {icon}
+      <span className={cn("grow", shrinkable && "lg:hidden xl:block")}>
+        {label}
+      </span>
+      {children}
+      {isHighlighted && (
+        <i
+          aria-hidden
+          className={cn(
+            "bg-destructive size-2.5 rounded-full",
+            shrinkable &&
+              "lg:absolute lg:top-1 lg:right-1 lg:size-1.5 xl:static xl:size-2.5",
+          )}
+        />
+      )}
+    </Link>
   );
 
   return shrinkable ?


### PR DESCRIPTION
## :recycle: Current situation & Problem

The `MenuItem` component wraps its `<Link>` in a redundant `<React.Fragment>`. When a Tooltip wraps `MenuItem`, it passes `aria-describedby` to the Fragment, which only accepts `key` and `children` props, producing a console error:

> `MenuLinks.tsx:31 Invalid prop 'aria-describedby' supplied to 'React.Fragment'.`


## :gear: Release Notes

- Remove unnecessary Fragment (`<>...</>`) wrapper around `<Link>` in `MenuItem`, fixing a React console warning about invalid props on Fragment.


## :books: Documentation

No public API changes were made.


## :white_check_mark: Testing

No test changes needed — this is a one-line wrapper removal with no behavioral change. The fix was verified by confirming the console error no longer appears.


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the menu item component's internal structure for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->