### PR TITLE
Forward isPending prop to ConfirmDeleteDialog

### DIFF
--- a/src/molecules/ConfirmDeleteDialog/ConfirmDeleteDialog.stories.tsx
+++ b/src/molecules/ConfirmDeleteDialog/ConfirmDeleteDialog.stories.tsx
@@ -67,3 +67,13 @@ export const MultipleItemsWithoutNames: Story = {
     entityName: "5 organizations",
   },
 };
+
+export const Pending: Story = {
+  args: {
+    open: true,
+    onDelete: action("onDelete"),
+    entityName: "user",
+    itemName: "example@example.com",
+    isPending: true,
+  },
+};

--- a/src/molecules/ConfirmDeleteDialog/ConfirmDeleteDialog.test.tsx
+++ b/src/molecules/ConfirmDeleteDialog/ConfirmDeleteDialog.test.tsx
@@ -64,6 +64,25 @@ describe("ConfirmDeleteDialog", () => {
     ).toBeInTheDocument();
   });
 
+  it("disables delete button and shows loader while pending", () => {
+    const onDelete = vitest.fn();
+    render(
+      <ConfirmDeleteDialog
+        open={true}
+        onOpenChange={vitest.fn()}
+        onDelete={onDelete}
+        entityName="user"
+        isPending
+      />,
+    );
+
+    const deleteButton = screen.getByRole("button", { name: "Loading" });
+    expect(deleteButton).toBeDisabled();
+
+    fireEvent.click(deleteButton);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
   it("truncates when more than 4 items", () => {
     render(
       <ConfirmDeleteDialog

--- a/src/molecules/ConfirmDeleteDialog/ConfirmDeleteDialog.test.tsx
+++ b/src/molecules/ConfirmDeleteDialog/ConfirmDeleteDialog.test.tsx
@@ -78,6 +78,7 @@ describe("ConfirmDeleteDialog", () => {
 
     const deleteButton = screen.getByRole("button", { name: "Loading" });
     expect(deleteButton).toBeDisabled();
+    expect(screen.getByTestId("buttonPendingLoader")).toBeInTheDocument();
 
     fireEvent.click(deleteButton);
     expect(onDelete).not.toHaveBeenCalled();

--- a/src/molecules/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/src/molecules/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -46,7 +46,7 @@ export interface ConfirmDeleteDialogProps
    * Reflects that the delete operation is in progress.
    * When true, the delete button shows a loader and is disabled
    * to prevent duplicate submissions.
-   * @default false
+   * @default undefined
    */
   isPending?: boolean;
 }
@@ -107,7 +107,7 @@ export const ConfirmDeleteDialog = ({
   entityName,
   itemName,
   onDelete,
-  isPending = false,
+  isPending,
   ...props
 }: ConfirmDeleteDialogProps) => {
   const itemNames =

--- a/src/molecules/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/src/molecules/ConfirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -42,6 +42,13 @@ export interface ConfirmDeleteDialogProps
    */
   itemName?: ReactNode | ReactNode[];
   onDelete: MouseEventHandler;
+  /**
+   * Reflects that the delete operation is in progress.
+   * When true, the delete button shows a loader and is disabled
+   * to prevent duplicate submissions.
+   * @default false
+   */
+  isPending?: boolean;
 }
 
 interface ItemNamesProps {
@@ -100,6 +107,7 @@ export const ConfirmDeleteDialog = ({
   entityName,
   itemName,
   onDelete,
+  isPending = false,
   ...props
 }: ConfirmDeleteDialogProps) => {
   const itemNames =
@@ -118,7 +126,12 @@ export const ConfirmDeleteDialog = ({
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button onClick={onDelete} variant="destructive">
+          <Button
+            onClick={onDelete}
+            variant="destructive"
+            isPending={isPending}
+            disabled={isPending}
+          >
             Delete {entityName}
           </Button>
         </DialogFooter>


### PR DESCRIPTION
## :recycle: Current situation & Problem

<img width="550" height="206" alt="image" src="https://github.com/user-attachments/assets/5f4d53ed-173c-4a9d-8f3d-cedab35a438c" />


`ConfirmDeleteDialog` invokes `onDelete`, which is frequently an async operation (mutation, network request). The dialog currently has no way to reflect that state — the Delete button stays enabled and shows no loader, allowing users to double-click and trigger duplicate deletions.

## :gear: Release Notes
- Add an `isPending?: boolean` prop to `ConfirmDeleteDialog` (defaults to `false`).
- When `isPending` is true, the Delete button shows a loader and is disabled, consistent with the existing `SaveButton` convention.

```tsx
<ConfirmDeleteDialog
  open={isOpen}
  onOpenChange={setIsOpen}
  entityName="user"
  itemName="alice@example.com"
  onDelete={handleDelete}
  isPending={deleteMutation.isPending}
/>
```

## :books: Documentation
The new prop is documented in-line via JSDoc on `ConfirmDeleteDialogProps`, matching the documentation style of the other props on the interface. No public API was removed or renamed.

## :white_check_mark: Testing
- Added a test that asserts the Delete button is disabled and carries `aria-label=\"Loading\"` when `isPending` is true, and that clicks while pending do not invoke `onDelete`.
- Added a `Pending` Storybook story so the loading state is discoverable in the component library.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).