### PR TITLE
Add CardContent, CardFooter, and CardDescription subcomponents

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -7,7 +7,14 @@
 //
 
 import { type Meta, type StoryObj } from "@storybook/react";
-import { Card } from "./Card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./Card";
 
 const meta: Meta<typeof Card> = {
   title: "Components/Card",
@@ -20,3 +27,48 @@ export default meta;
 type Story = StoryObj<typeof Card>;
 
 export const Default: Story = {};
+
+export const WithHeader: Story = {
+  args: {
+    children: (
+      <>
+        <CardHeader>
+          <CardTitle>Card Title</CardTitle>
+        </CardHeader>
+        <CardContent>Card content goes here.</CardContent>
+      </>
+    ),
+  },
+};
+
+export const WithHeaderAndDescription: Story = {
+  args: {
+    children: (
+      <>
+        <CardHeader>
+          <CardTitle>Card Title</CardTitle>
+          <CardDescription>A short description of this card.</CardDescription>
+        </CardHeader>
+        <CardContent>Card content goes here.</CardContent>
+      </>
+    ),
+  },
+};
+
+export const Full: Story = {
+  args: {
+    children: (
+      <>
+        <CardHeader>
+          <CardTitle>Patient Overview</CardTitle>
+          <CardDescription>Last updated 2 hours ago</CardDescription>
+        </CardHeader>
+        <CardContent>
+          Heart rate, blood pressure, and oxygen levels are all within normal
+          range. No alerts triggered in the last 24 hours.
+        </CardContent>
+        <CardFooter>Synced from Apple Health</CardFooter>
+      </>
+    ),
+  },
+};

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -28,7 +28,7 @@ type Story = StoryObj<typeof Card>;
 
 export const Default: Story = {};
 
-export const WithHeader: Story = {
+export const WithTitle: Story = {
   args: {
     children: (
       <>
@@ -41,7 +41,7 @@ export const WithHeader: Story = {
   },
 };
 
-export const WithHeaderAndDescription: Story = {
+export const WithTitleAndDescription: Story = {
   args: {
     children: (
       <>

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -7,7 +7,14 @@
 //
 
 import { render, screen } from "@testing-library/react";
-import { Card, CardHeader, CardTitle } from ".";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from ".";
 
 describe("Card", () => {
   it("renders element", () => {
@@ -48,5 +55,28 @@ describe("Card", () => {
 
     const heading = screen.getByRole("heading", { level: 2 });
     expect(heading).toHaveTextContent("Custom heading");
+  });
+
+  it("renders CardDescription", () => {
+    render(
+      <CardHeader>
+        <CardTitle>Title</CardTitle>
+        <CardDescription>Some description</CardDescription>
+      </CardHeader>,
+    );
+
+    expect(screen.getByText("Some description")).toBeInTheDocument();
+  });
+
+  it("renders CardContent", () => {
+    render(<CardContent>Body text</CardContent>);
+
+    expect(screen.getByText("Body text")).toBeInTheDocument();
+  });
+
+  it("renders CardFooter", () => {
+    render(<CardFooter>Footer note</CardFooter>);
+
+    expect(screen.getByText("Footer note")).toBeInTheDocument();
   });
 });

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -78,7 +78,7 @@ type CardHeaderProps = ComponentProps<"div">;
 export const CardHeader = ({ className, ...props }: CardHeaderProps) => (
   <header
     data-slot="card-header"
-    className={cn("mb-4 flex items-center gap-2 px-5 pt-4", className)}
+    className={cn("mb-4 flex flex-col gap-1 px-5 pt-4", className)}
     {...props}
   />
 );
@@ -109,3 +109,81 @@ export const CardTitle = ({ className, asChild, ...props }: CardTitleProps) => {
     />
   );
 };
+
+type CardDescriptionProps = ComponentProps<"p">;
+
+/**
+ * Description component for {@link CardHeader|card headers}.
+ *
+ * Renders muted secondary text below {@link CardTitle}. Typically wrapped by {@link CardHeader}.
+ *
+ * @example
+ * ```tsx
+ * <CardHeader>
+ *   <CardTitle>Settings</CardTitle>
+ *   <CardDescription>Manage your account preferences</CardDescription>
+ * </CardHeader>
+ * ```
+ */
+export const CardDescription = ({
+  className,
+  ...props
+}: CardDescriptionProps) => (
+  <p
+    data-slot="card-description"
+    className={cn("text-muted-foreground text-sm", className)}
+    {...props}
+  />
+);
+
+type CardContentProps = ComponentProps<"div">;
+
+/**
+ * Content area component for {@link Card}.
+ *
+ * Provides consistent horizontal padding and bottom spacing for card body content.
+ * Replaces the manual `<div className="p-5">` pattern.
+ *
+ * @example
+ * ```tsx
+ * <Card>
+ *   <CardHeader>
+ *     <CardTitle>Overview</CardTitle>
+ *   </CardHeader>
+ *   <CardContent>Your content here</CardContent>
+ * </Card>
+ * ```
+ */
+export const CardContent = ({ className, ...props }: CardContentProps) => (
+  <div
+    data-slot="card-content"
+    className={cn("px-5 pb-5", className)}
+    {...props}
+  />
+);
+
+type CardFooterProps = ComponentProps<"footer">;
+
+/**
+ * Footer component for {@link Card}.
+ *
+ * Provides consistent spacing for a right-aligned smaller line of text at the bottom of a card.
+ *
+ * @example
+ * ```tsx
+ * <Card>
+ *   <CardContent>Main content</CardContent>
+ *   <CardFooter>Synced from Apple Health</CardFooter>
+ * </Card>
+ * ```
+ */
+export const CardFooter = ({ className, ...props }: CardFooterProps) => (
+  <footer
+    data-slot="card-footer"
+    className={cn(
+      "text-muted-foreground px-5 pb-4 text-right text-sm",
+      className,
+    )}
+    {...props}
+  />
+);

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -36,8 +36,9 @@ export interface CardProps
  * <Card>
  *   <CardHeader>
  *     <CardTitle>Card Title</CardTitle>
+ *     <CardDescription>Card description</CardDescription>
  *   </CardHeader>
- *   <div className="p-5">Card content goes here</div>
+ *   <CardContent>Card content goes here</CardContent>
  * </Card>
  * ```
  *
@@ -69,9 +70,9 @@ type CardHeaderProps = ComponentProps<"div">;
  * <Card>
  *   <CardHeader>
  *     <CardTitle>Card Title</CardTitle>
- *     <p className="text-sm text-muted-foreground">Card description</p>
+ *     <CardDescription>Card description</CardDescription>
  *   </CardHeader>
- *   <div className="p-5">Card content</div>
+ *   <CardContent>Card content goes here</CardContent>
  * </Card>
  * ```
  */


### PR DESCRIPTION
# *Add CardContent, CardFooter, and CardDescription subcomponents*

## :recycle: Current situation & Problem
Issue #173 
The Card component provides a styled container but has no standard subcomponents for common layout patterns. Users had to add manual padding divs `(<div className="p-5">)` for content areas, and there was no standardised way to add a description below the title or a footer at the bottom of a card

## :gear: Release Notes
- Added CardDescription: a muted secondary text component rendered below CardTitle inside CardHeader                                                   
- Added CardContent: a padded content area replacing the manual `<div className="p-5">` pattern
- Added CardFooter: a right-aligned, smaller text footer at the bottom of a card
- Breaking change: CardHeader layout changed from a horizontal row `(flex items-center gap-2)` to a vertical column `(flex flex-col gap-1)` to support title + description stacking. Users using CardHeader with side-by-side children should wrap them in a row div

// Before                                                                     
```
  <Card>              
    <CardHeader>                                                                
      <CardTitle>Patient Overview</CardTitle>
    </CardHeader>                                                               
    <div className="p-5">Content here</div>
  </Card>       
```                                                                
                                         
// After                  
 ```
 <Card>              
    <CardHeader> 
      <CardTitle>Patient Overview</CardTitle>
      <CardDescription>Last updated 2 hours ago</CardDescription>               
    </CardHeader>                        
    <CardContent>Content here</CardContent>                                     
    <CardFooter>Synced from Apple Health</CardFooter>
  </Card>
```


## :books: Documentation
All new components are documented with JSDoc including usage examples and cross-references to related components (@link CardHeader, @link CardTitle). The CardHeader doc is updated to reflect the new column layout


## :white_check_mark: Testing
3 new tests added to Card.test.tsx covering CardDescription, CardContent, and CardFooter

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
